### PR TITLE
Fix #3

### DIFF
--- a/src/main/java/core/packetproxy/EncoderManager.java
+++ b/src/main/java/core/packetproxy/EncoderManager.java
@@ -66,7 +66,6 @@ public class EncoderManager
 	}
 	private void loadModules() throws Exception {
 		module_list = new HashMap<String,Class<Encoder>>();
-		loadModulesFromJar(module_list);
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 		JavaFileManager fm = compiler.getStandardFileManager(new DiagnosticCollector<JavaFileObject>(), null, null);
 
@@ -82,6 +81,7 @@ public class EncoderManager
 				module_list.put(encoder.getName(), klass);
 			}
 		}
+		loadModulesFromJar(module_list);
 	}
 
 	private void loadModulesFromJar(HashMap<String,Class<Encoder>> module_list) throws Exception
@@ -124,7 +124,11 @@ public class EncoderManager
 
 				@SuppressWarnings("unchecked")
 				Encoder encoder = createInstance((Class<Encoder>) klass);
-				module_list.put(encoder.getName(),(Class<Encoder>)klass);
+				String encoderName = encoder.getName();
+				if(module_list.containsKey(encoderName)){
+					encoderName += "-" + file.getName();
+				}
+				module_list.put(encoderName, (Class<Encoder>)klass);
 			}
 		}
 	}

--- a/src/main/java/core/packetproxy/EncoderManager.java
+++ b/src/main/java/core/packetproxy/EncoderManager.java
@@ -42,6 +42,7 @@ import packetproxy.encode.Encoder;
 public class EncoderManager
 {
 	private static EncoderManager incetance;
+	private boolean isDuplicated = false;
 	
 	public static EncoderManager getInstance() throws Exception {
 		if (incetance == null) {
@@ -65,6 +66,7 @@ public class EncoderManager
 		}
 	}
 	private void loadModules() throws Exception {
+		isDuplicated = false;
 		module_list = new HashMap<String,Class<Encoder>>();
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 		JavaFileManager fm = compiler.getStandardFileManager(new DiagnosticCollector<JavaFileObject>(), null, null);
@@ -126,11 +128,16 @@ public class EncoderManager
 				Encoder encoder = createInstance((Class<Encoder>) klass);
 				String encoderName = encoder.getName();
 				if(module_list.containsKey(encoderName)){
+					isDuplicated = true;
 					encoderName += "-" + file.getName();
 				}
 				module_list.put(encoderName, (Class<Encoder>)klass);
 			}
 		}
+	}
+
+	public boolean hasDuplicateModules(){
+		return isDuplicated;
 	}
 
 	public String[] getEncoderNameList() {

--- a/src/main/java/core/packetproxy/gui/GUIOptionServerDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionServerDialog.java
@@ -15,6 +15,7 @@
  */
 package packetproxy.gui;
 
+import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.EventQueue;
@@ -30,7 +31,6 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.WindowConstants;
 import packetproxy.EncoderManager;
 import packetproxy.model.Server;
 
@@ -102,6 +102,21 @@ public class GUIOptionServerDialog extends JDialog
 		setVisible(true);
 		return server;
 	}
+
+	private JComponent createModuleAlert() throws  Exception {
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+		JLabel label = new JLabel(
+				"<html>名前が重複したEncodeモジュールがあります。<br/>" +
+				"重複したEncodeモジュールの名前は<br/>" +
+				"{モジュール名}-{モジュールのJarファイル名}として扱われます。</html>"
+		);
+		label.setForeground(Color.red);
+		label.setPreferredSize(new Dimension(150, label.getMaximumSize().height));
+		panel.add(label);
+		return panel;
+	}
+
 	private JComponent createModuleSetting() throws Exception {
 		String[] names = EncoderManager.getInstance().getEncoderNameList();
 		for (int i = 0; i < names.length; i++) {
@@ -161,6 +176,9 @@ public class GUIOptionServerDialog extends JDialog
 	    panel.add(createIpSetting());
 	    panel.add(createPortSetting());
 	    panel.add(createUseSSLSetting());
+	    if(EncoderManager.getInstance().hasDuplicateModules()){
+	        panel.add(createModuleAlert());
+	    }
 	    panel.add(createModuleSetting());
 	    panel.add(createDNSSetting());
 	    panel.add(createHttpProxySetting());


### PR DESCRIPTION
#3 
のIssueの修正案です。
エンコードモジュールが重複した際に
Options->Servers->Add/Editで表示されるダイアログに次の警告の文章を出すようにしました。
```
名前が重複したEncodeモジュールがあります。
重複したEncodeモジュールの名前は
{モジュール名}-{モジュールのJarファイル名}として扱われます。
```

また、上記の警告文章にある通り、
Jarから読み込んだEncodeモジュールのgetName()がビルドインのEncodeモジュールや
他のJarから読み込んだEncodeモジュールと重複しているしている場合に
あとから呼んだものを{モジュール名}-{モジュールのJarファイル名}として表示するようにしました。