### PR TITLE
Bug Fix: add default japanese font mapping

### DIFF
--- a/src/main/java/core/packetproxy/common/FontManager.java
+++ b/src/main/java/core/packetproxy/common/FontManager.java
@@ -38,6 +38,7 @@ public class FontManager {
 			put(new MultiKey<String>("Mac",     Locale.JAPAN.getLanguage()),   new LocaleFontStyles(new FontStyle("SansSerif",12), new FontStyle("Monospaced", 12)));
 			put(new MultiKey<String>("Mac",     Locale.ENGLISH.getLanguage()), new LocaleFontStyles(new FontStyle("SansSerif",12), new FontStyle("Monospaced", 12)));
 			put(new MultiKey<String>("Default", Locale.ENGLISH.getLanguage()), new LocaleFontStyles(new FontStyle("SansSerif",12), new FontStyle("Monospaced", 12)));
+			put(new MultiKey<String>("Default", Locale.JAPAN.getLanguage()), new LocaleFontStyles(new FontStyle("SansSerif",12), new FontStyle("Monospaced", 12)));
         }
     };
 


### PR DESCRIPTION
下記状態で起動に失敗するバグを見つけたので修正しました。

## 再現方法

OS: Ubuntu(Linux)

```
shiota@ubuntu ~/git/PacketProxy
 % echo $LANG
ja_JP.UTF-8

shiota@ubuntu ~/git/PacketProxy
 % rm ~/.packetproxy/db/*

shiota@ubuntu ~/git/PacketProxy
 % ./gradlew assemble &&  java -jar ./build/libs/PacketProxy.jar

BUILD SUCCESSFUL in 3s
6 actionable tasks: 4 executed, 2 up-to-date
2019/11/03 18:19:39       null
2019/11/03 18:19:39       packetproxy.common.FontManager.createUIFont(FontManager.java:68)
2019/11/03 18:19:39       packetproxy.common.FontManager.<init>(FontManager.java:45)
2019/11/03 18:19:39       packetproxy.common.FontManager.getInstance(FontManager.java:22)
2019/11/03 18:19:39       packetproxy.gui.GUIMain.setLookandFeel(GUIMain.java:185)
2019/11/03 18:19:39       packetproxy.gui.GUIMain.<init>(GUIMain.java:110)
2019/11/03 18:19:39       packetproxy.gui.GUIMain.getInstance(GUIMain.java:77)
2019/11/03 18:19:39       packetproxy.PacketProxy.startGUI(PacketProxy.java:99)
2019/11/03 18:19:39       packetproxy.PacketProxy.start(PacketProxy.java:89)
2019/11/03 18:19:39       packetproxy.PacketProxy.main(PacketProxy.java:56)
java.lang.NullPointerException
        at packetproxy.common.FontManager.createUIFont(FontManager.java:68)
        at packetproxy.common.FontManager.<init>(FontManager.java:45)
        at packetproxy.common.FontManager.getInstance(FontManager.java:22)
        at packetproxy.gui.GUIMain.setLookandFeel(GUIMain.java:185)
        at packetproxy.gui.GUIMain.<init>(GUIMain.java:110)
        at packetproxy.gui.GUIMain.getInstance(GUIMain.java:77)
        at packetproxy.PacketProxy.startGUI(PacketProxy.java:99)
        at packetproxy.PacketProxy.start(PacketProxy.java:89)
        at packetproxy.PacketProxy.main(PacketProxy.java:56)
```
