### PR TITLE
Improved speed of deletion.

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIHistory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistory.java
@@ -556,8 +556,8 @@ public class GUIHistory implements Observer
 					for(int i=0;i<table.getRowCount();++i) {
 						Integer id = (Integer) table.getValueAt(i, 0);
 						colorManager.clear(id);
-						packets.delete(packets.query(id));
 					}
+					packets.deleteAll();
 					updateAll();
 				} catch (Exception e2) {
 					e2.printStackTrace();


### PR DESCRIPTION
数千件のパケットログがある状態での、delete all itemsの時間が非常にかかる部分を修正しました。
・6000件程の削除でのテスト
修正前:1分以上
修正後:12秒程
