### PR TITLE
Fix gRPC is not working when ALPN is h2.

### DIFF
--- a/src/main/java/core/packetproxy/encode/EncodeGRPC.java
+++ b/src/main/java/core/packetproxy/encode/EncodeGRPC.java
@@ -17,6 +17,7 @@ package packetproxy.encode;
 
 import packetproxy.common.Protobuf3;
 import packetproxy.http.Http;
+import packetproxy.http2.Grpc;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -27,7 +28,7 @@ public class EncodeGRPC extends EncodeHTTPBase
 	private byte compressedFlag;
 
 	public EncodeGRPC(String ALPN) throws Exception {
-		super(ALPN);
+		super(ALPN, new Grpc());
 	}
 
 	@Override

--- a/src/main/java/core/packetproxy/encode/EncodeHTTPBase.java
+++ b/src/main/java/core/packetproxy/encode/EncodeHTTPBase.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 
 import packetproxy.http.Http;
 import packetproxy.http2.FramesBase;
-import packetproxy.http2.Grpc;
 import packetproxy.http2.Http2;
 import packetproxy.model.Packet;
 
@@ -45,9 +44,20 @@ public abstract class EncodeHTTPBase extends Encoder
 		} else if (ALPN.equals("h2")) {
 			httpVersion = HTTPVersion.HTTP2;
 			http2 = new Http2();
-		} else if (ALPN.equals("grpc") || ALPN.equals("grpc-exp")) {
+		} else {
+			httpVersion = HTTPVersion.HTTP1;
+		}
+	}
+
+	public EncodeHTTPBase(String ALPN, FramesBase http2CustomFrame) throws Exception {
+		super(ALPN);
+		if (ALPN == null) {
+			httpVersion = HTTPVersion.HTTP1;
+		} else if (ALPN.equals("http/1.0") || ALPN.equals("http/1.1")) {
+			httpVersion = HTTPVersion.HTTP1;
+		} else if (ALPN.equals("h2")) {
 			httpVersion = HTTPVersion.HTTP2;
-			http2 = new Grpc();
+			this.http2 = http2CustomFrame;
 		} else {
 			httpVersion = HTTPVersion.HTTP1;
 		}


### PR DESCRIPTION
#61 の修正です．
gRPCのエンコードモジュールを指定したときかつHTTP/2でやり取りされていたときに
gRPC用のフレームの処理を必ず行うようにしました． 