### PR TITLE
PrivateDNS関連のバグの修正。

### DIFF
--- a/src/main/java/core/packetproxy/PrivateDNS.java
+++ b/src/main/java/core/packetproxy/PrivateDNS.java
@@ -64,7 +64,9 @@ public class PrivateDNS
 				for (InterfaceAddress intAddress : netint.getInterfaceAddresses()) {
 					InetAddress addr = intAddress.getAddress();
 					if (addr instanceof Inet4Address) {
-						String cidr = String.format("%s/%d", addr.getHostAddress(), intAddress.getNetworkPrefixLength());
+						short length = intAddress.getNetworkPrefixLength();
+						if(length<0)continue;
+						String cidr = String.format("%s/%d", addr.getHostAddress(),length);
 						SubnetUtils subnet = new SubnetUtils(cidr);
 						subnets.add(subnet.getInfo());
 						if (defaultAddr == null) {


### PR DESCRIPTION
VPN環境下でPacketProxyが起動後画像のような状態になるバグが複数PCで見られました。(Windows)

<img width="815" alt="bug" src="https://user-images.githubusercontent.com/56913432/95283520-fdbbec00-0896-11eb-8c1b-1b88fe762056.png">

エラーログからgetNetworkPrefixLengthが-1を返し、Parse出来ないことによるエラーであると判明しました。
よって-1の場合無視するように修正したところ無事起動するようになりました。
