### PR TITLE
Fixed the behavior when the forwarding server is deleted.

### DIFF
--- a/src/main/java/core/packetproxy/common/ConfigHttpServer.java
+++ b/src/main/java/core/packetproxy/common/ConfigHttpServer.java
@@ -42,7 +42,12 @@ public class ConfigHttpServer extends NanoHTTPD {
     private void fixUpListenPortList(Map<Integer,Integer> serverMap, List<ListenPort> listenPortList) {
         int i = 1;
         for (ListenPort listenPort : listenPortList) {
-            listenPort.setServerId(serverMap.get(listenPort.getServerId()));
+            int id = listenPort.getServerId();
+            if(serverMap.containsKey(id)){
+                listenPort.setServerId(serverMap.get(id));
+            }else{
+                listenPort.setServerId(-1);
+            }
             listenPort.setId(i);
             i++;
         }

--- a/src/main/java/core/packetproxy/common/ConfigIO.java
+++ b/src/main/java/core/packetproxy/common/ConfigIO.java
@@ -39,7 +39,12 @@ public class ConfigIO{
     private void fixUpListenPortList(Map<Integer,Integer> serverMap, List<ListenPort> listenPortList) {
         int i = 1;
         for (ListenPort listenPort : listenPortList) {
-            listenPort.setServerId(serverMap.get(listenPort.getServerId()));
+            int id = listenPort.getServerId();
+            if(serverMap.containsKey(id)){
+                listenPort.setServerId(serverMap.get(id));
+            }else{
+                listenPort.setServerId(-1);
+            }
             listenPort.setId(i);
             i++;
         }

--- a/src/main/java/core/packetproxy/gui/GUIOptionListenPorts.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionListenPorts.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.swing.JFrame;
 
 import packetproxy.model.ListenPort;
+import packetproxy.model.ListenPort.TYPE;
 import packetproxy.model.ListenPorts;
 
 public class GUIOptionListenPorts extends GUIOptionComponentBase<ListenPort>
@@ -112,12 +113,16 @@ public class GUIOptionListenPorts extends GUIOptionComponentBase<ListenPort>
 	protected void addTableContent(ListenPort listenPort) {
 		table_ext_list.add(listenPort);
 		try {
+			String serverNullStr = "";
+			TYPE type = listenPort.getType();
+			if(type==TYPE.FORWARDER || type==TYPE.SSL_FORWARDER || type==TYPE.UDP_FORWARDER)
+				serverNullStr = "Deleted";
 			option_model.addRow(new Object[] {
 				listenPort.isEnabled(),
 					listenPort.getPort(),
 					listenPort.getType(),
 					listenPort.getCA().map(ca -> ca.getName()).orElse("Error"),
-					listenPort.getServer() != null ? listenPort.getServer().toString() : ""});
+					listenPort.getServer() != null ? listenPort.getServer().toString() : serverNullStr});
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
FORWARDER等に登録されたサーバが削除された場合の挙動を修正しました。
・GUI上で何も表示していなかったのを、"Deleted"と表示するようにしました。
・設定の保存時、サーバが削除されていた場合serverIdを-1にするようにしました。
=> #85 の修正。

