### PR TITLE
SSL PassThroughの項目が削除出来なくなっていたバグを修正 + typo

### DIFF
--- a/src/main/java/core/packetproxy/common/ConfigHttpServer.java
+++ b/src/main/java/core/packetproxy/common/ConfigHttpServer.java
@@ -20,7 +20,7 @@ public class ConfigHttpServer extends NanoHTTPD {
         @SerializedName(value="listenPorts") List<ListenPort> listenPortList;
         @SerializedName(value="servers") List<Server> serverList;
         @SerializedName(value="modifications") List<Modification> modificationList;
-        @SerializedName(value="sslPathThroughs") List<SSLPassThrough> sslPassThroughList;
+        @SerializedName(value="sslPassThroughs") List<SSLPassThrough> sslPassThroughList;
     }
 
     public ConfigHttpServer(String hostname, int port, String allowedAccessToken) {

--- a/src/main/java/core/packetproxy/common/ConfigIO.java
+++ b/src/main/java/core/packetproxy/common/ConfigIO.java
@@ -18,7 +18,7 @@ public class ConfigIO{
         @SerializedName(value="listenPorts") List<ListenPort> listenPortList;
         @SerializedName(value="servers") List<Server> serverList;
         @SerializedName(value="modifications") List<Modification> modificationList;
-        @SerializedName(value="sslPathThroughs") List<SSLPassThrough> sslPassThroughList;
+        @SerializedName(value="sslPassThroughs") List<SSLPassThrough> sslPassThroughList;
     }
 
     public ConfigIO() {

--- a/src/main/java/core/packetproxy/model/SSLPassThroughs.java
+++ b/src/main/java/core/packetproxy/model/SSLPassThroughs.java
@@ -65,6 +65,7 @@ public class SSLPassThroughs extends Observable implements Observer
 	}
 	public void delete(SSLPassThrough sslPassThrough) throws Exception {
 		dao.delete(sslPassThrough);
+		cache.clear();
 		notifyObservers();
 	}
 	public void update(SSLPassThrough sslPassThrough) throws Exception {


### PR DESCRIPTION
#97
よりSSLPassThroughの項目が削除できない不具合が発生していました。
cache.clearの記述漏れがあったので修正しました。

設定をAPIでインポート/エクスポート、jsonファイルに読み込み/書き込みする機能でtypoがあったので修正しました。
sslPathThroughs => sslPassThroughs
(※これによりそのままではこの修正以前のjsonファイルを上手く読み込めないかもしれません。)
