### PR TITLE
SSL PassThroughの項目が削除出来なくなっていたバグを修正 + typo

### DIFF
--- a/src/main/java/core/packetproxy/common/ConfigHttpServer.java
+++ b/src/main/java/core/packetproxy/common/ConfigHttpServer.java
@@ -20,7 +20,7 @@ public class ConfigHttpServer extends NanoHTTPD {
         @SerializedName(value="listenPorts") List<ListenPort> listenPortList;
         @SerializedName(value="servers") List<Server> serverList;
         @SerializedName(value="modifications") List<Modification> modificationList;
-        @SerializedName(value="sslPathThroughs") List<SSLPassThrough> sslPassThroughList;
+        @SerializedName(value="sslPassThroughs") List<SSLPassThrough> sslPassThroughList;
     }
 
     public ConfigHttpServer(String hostname, int port, String allowedAccessToken) {

--- a/src/main/java/core/packetproxy/common/ConfigIO.java
+++ b/src/main/java/core/packetproxy/common/ConfigIO.java
@@ -18,7 +18,7 @@ public class ConfigIO{
         @SerializedName(value="listenPorts") List<ListenPort> listenPortList;
         @SerializedName(value="servers") List<Server> serverList;
         @SerializedName(value="modifications") List<Modification> modificationList;
-        @SerializedName(value="sslPathThroughs") List<SSLPassThrough> sslPassThroughList;
+        @SerializedName(value="sslPassThroughs") List<SSLPassThrough> sslPassThroughList;
     }
 
     public ConfigIO() {
@@ -66,48 +66,38 @@ public class ConfigIO{
         fixUpModificationList(serverMap, daoHub.modificationList);
     }
 
-    public String getOptions() {
-            try {
-                DaoHub daoHub = new DaoHub();
+    public String getOptions() throws Exception {
+		DaoHub daoHub = new DaoHub();
 
-                daoHub.listenPortList = ListenPorts.getInstance().queryAll();
-                daoHub.serverList = Servers.getInstance().queryAll();
-                daoHub.modificationList = Modifications.getInstance().queryAll();
-                daoHub.sslPassThroughList = SSLPassThroughs.getInstance().queryAll();
+		daoHub.listenPortList = ListenPorts.getInstance().queryAll();
+		daoHub.serverList = Servers.getInstance().queryAll();
+		daoHub.modificationList = Modifications.getInstance().queryAll();
+		daoHub.sslPassThroughList = SSLPassThroughs.getInstance().queryAll();
 
-                fixUp(daoHub);
+		fixUp(daoHub);
 
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                String json = gson.toJson(daoHub);
-                
-                return json;
-
-            } catch (Exception e) {
-                e.printStackTrace();
-                return null;
-            }
+		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		String json = gson.toJson(daoHub);
+		
+		return json;
     }
 
-    public void setOptions(String json){
-            try{
-                DaoHub daoHub = new Gson().fromJson(json, DaoHub.class);
+    public void setOptions(String json) throws Exception {
+		DaoHub daoHub = new Gson().fromJson(json, DaoHub.class);
 
-                Database.getInstance().dropConfigs();
+		Database.getInstance().dropConfigs();
 
-                for (ListenPort listenPort : daoHub.listenPortList) {
-                    ListenPorts.getInstance().create(listenPort);
-                }
-                for (Server server : daoHub.serverList) {
-                    Servers.getInstance().create(server);
-                }
-                for (Modification mod : daoHub.modificationList) {
-                    Modifications.getInstance().create(mod);
-                }
-                for (SSLPassThrough passThrough : daoHub.sslPassThroughList) {
-                    SSLPassThroughs.getInstance().create(passThrough);
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+		for (ListenPort listenPort : daoHub.listenPortList) {
+			ListenPorts.getInstance().create(listenPort);
+		}
+		for (Server server : daoHub.serverList) {
+			Servers.getInstance().create(server);
+		}
+		for (Modification mod : daoHub.modificationList) {
+			Modifications.getInstance().create(mod);
+		}
+		for (SSLPassThrough passThrough : daoHub.sslPassThroughList) {
+			SSLPassThroughs.getInstance().create(passThrough);
+		}
+	}
 }

--- a/src/main/java/core/packetproxy/model/SSLPassThroughs.java
+++ b/src/main/java/core/packetproxy/model/SSLPassThroughs.java
@@ -65,6 +65,7 @@ public class SSLPassThroughs extends Observable implements Observer
 	}
 	public void delete(SSLPassThrough sslPassThrough) throws Exception {
 		dao.delete(sslPassThrough);
+		cache.clear();
 		notifyObservers();
 	}
 	public void update(SSLPassThrough sslPassThrough) throws Exception {


### PR DESCRIPTION
(1)
#97
よりSSLPassThroughの項目が削除できない不具合が発生していました。
cache.clearの記述漏れがあったので修正しました。

(2)
設定をAPIでインポート/エクスポート、jsonファイルに読み込み/書き込みする機能でtypoがあったので修正しました。
sslPathThroughs => sslPassThroughs
(※これによりそのままではこの修正以前のjsonファイルを上手く読み込めないかもしれません。)

(3)
ConfigIO.javaで例外処理の実装ミスで一部読み込みに失敗しても「読み込みに成功しましたと表示される」不具合を修正しました。