### PR TITLE
bulksenderにパラメータ機能を追加

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIBulkSender.java
+++ b/src/main/java/core/packetproxy/gui/GUIBulkSender.java
@@ -110,7 +110,7 @@ public class GUIBulkSender {
 					OneShotPacket[] oneshots = (OneShotPacket[]) sendPackets.values().toArray(new OneShotPacket[0]);
 
 					if (regexParams.size() == 0) { // parallel
-						ResendController.getInstance().resend(new ResendWorker(oneshots, 100) {
+						ResendController.getInstance().resend(new ResendWorker(oneshots) {
 							@Override
 							protected void process(List<OneShotPacket> oneshots) {
 								try {

--- a/src/main/java/core/packetproxy/gui/GUIBulkSenderData.java
+++ b/src/main/java/core/packetproxy/gui/GUIBulkSenderData.java
@@ -25,6 +25,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+
 public class GUIBulkSenderData {
 
 	//private JFrame owner;

--- a/src/main/java/core/packetproxy/gui/GUIRegexParamDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIRegexParamDialog.java
@@ -1,0 +1,106 @@
+package packetproxy.gui;
+
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+
+import packetproxy.common.I18nString;
+import packetproxy.model.RegexParam;
+
+public class GUIRegexParamDialog extends JDialog {
+    private JButton button_cancel = new JButton(I18nString.get("Cancel"));
+    private JButton button_set = new JButton(I18nString.get("Save"));
+    private JTextField regex = new JTextField();
+    private JTextField name = new JTextField();
+    private int height = 500;
+    private int width = 500;
+    private RegexParam regexParam = null;
+
+    private JComponent label_and_object(String label_name, JComponent object) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        JLabel label = new JLabel(label_name);
+        label.setPreferredSize(new Dimension(150, label.getMaximumSize().height));
+        panel.add(label);
+        object.setMaximumSize(new Dimension(Short.MAX_VALUE, label.getMaximumSize().height * 2));
+        panel.add(object);
+        return panel;
+    }
+
+    private JComponent buttons() {
+        JPanel panel_button = new JPanel();
+        panel_button.setLayout(new BoxLayout(panel_button, BoxLayout.X_AXIS));
+        panel_button.setMaximumSize(new Dimension(Short.MAX_VALUE, button_set.getMaximumSize().height));
+        panel_button.add(button_cancel);
+        panel_button.add(button_set);
+        return panel_button;
+    }
+
+    public RegexParam showDialog(RegexParam regexParam) throws Exception {
+        this.regexParam = regexParam;
+        regex.setText(regexParam.getRegex());
+        name.setText(regexParam.getName());
+        setModal(true);
+        setVisible(true);
+        return this.regexParam;
+    }
+
+    public RegexParam showDialog() {
+        setModal(true);
+        setVisible(true);
+        return regexParam;
+    }
+
+    private JComponent createNameSetting() {
+        return label_and_object("Param Name:", name);
+    }
+
+    private JComponent createRegexString() {
+        return label_and_object("regex to pickup", regex);
+    }
+    
+    public GUIRegexParamDialog(JFrame owner) throws Exception {
+        super(owner);
+        setTitle("RegexParam setting");
+
+        Rectangle rect = owner.getBounds();
+        setBounds(rect.x + rect.width / 2 - width / 2, rect.y + rect.height / 2 - height / 2, width, height);
+
+        Container c = getContentPane();
+        JPanel panel = new JPanel();
+        panel.add(createNameSetting());
+        panel.add(createRegexString());
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        panel.add(buttons());
+
+        c.add(panel);
+
+        button_cancel.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                regexParam = null;
+                dispose();
+            }
+        });
+
+        button_set.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                regexParam = new RegexParam(regexParam.getPacketId(), name.getText(), regex.getText());
+                dispose();
+            }
+        });
+    }
+}

--- a/src/main/java/core/packetproxy/gui/GUIRegexParamsTableDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIRegexParamsTableDialog.java
@@ -1,0 +1,227 @@
+package packetproxy.gui;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.List;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.table.TableRowSorter;
+
+import packetproxy.common.FontManager;
+import packetproxy.model.OptionTableModel;
+import packetproxy.model.RegexParam;
+
+public class GUIRegexParamsTableDialog extends JDialog {
+    private JFrame owner;
+    private int width;
+    private int height = 300;
+    private JPanel main_panel;
+    private JTable table;
+    private List<RegexParam> regexParams;
+    private int basePacketId;
+    private OptionTableModel option_model;
+    private static String[] menu = {"Base Packet ID", "Param Name",  "Regex to pickup"};
+    private static int[] menuWidth = { 100, 50, 200 };
+
+    public List<RegexParam> showDialog() {
+        try {
+            updateTable();
+            setModal(true);
+            setVisible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return this.regexParams;
+    }
+
+    public void updateTable() {
+        option_model.setRowCount(0);
+        for (RegexParam regex : regexParams) {
+            option_model.addRow(new Object[]{
+                regex.getPacketId(),
+                regex.getName(),
+                regex.getRegex()
+            });
+        }
+    }
+
+    public GUIRegexParamsTableDialog(JFrame owner, List<RegexParam> regexParams, int packetId) throws Exception {
+        super(owner);
+        this.owner = owner;
+
+        this.regexParams = regexParams;
+        this.basePacketId = packetId;
+
+        setTitle("regex params");
+
+        createPanel();
+        updateTable();
+        Container c = getContentPane();
+        c.setLayout(new BoxLayout(c, BoxLayout.Y_AXIS));
+        c.add(main_panel);
+
+        Rectangle rect = owner.getBounds();
+        width = rect.width - 100;
+        setBounds(rect.x + rect.width / 2 - width / 2, rect.y + rect.height / 2 - height / 2, width, height);
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent event) {
+                try {
+                    dispose();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    public JComponent createPanel() throws Exception {
+        MouseAdapter tableAction = new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                try {
+                    int rowIndex = table.rowAtPoint(e.getPoint());
+                    table.setRowSelectionInterval(rowIndex, rowIndex);
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+
+        ActionListener addAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    GUIRegexParamDialog dlg = new GUIRegexParamDialog(owner);
+                    RegexParam regexParam = dlg.showDialog(new RegexParam(basePacketId, "", ""));
+                    if (regexParam != null) {
+                        regexParams.add(regexParam);
+                    }
+                    updateTable();
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+        ActionListener editAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    RegexParam oldRegexParam = getSelectedTableContent();
+                    GUIRegexParamDialog dlg = new GUIRegexParamDialog(owner); 
+                    RegexParam newRegexParam = dlg.showDialog(oldRegexParam);
+                    if (newRegexParam != null) {
+                        regexParams.remove(oldRegexParam);
+                        regexParams.add(newRegexParam);
+                    }
+                    updateTable();
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+        ActionListener removeAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    regexParams.remove(getSelectedTableContent());
+                    updateTable();
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+
+        main_panel = new JPanel();
+        main_panel.setLayout(new BoxLayout(main_panel, BoxLayout.X_AXIS));
+
+        option_model = new OptionTableModel(menu, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+        TableRowSorter<OptionTableModel> sorter = new TableRowSorter<>(option_model);
+        table = new JTable(option_model);
+        for (int i = 0; i < menu.length; i++) {
+			table.getColumn(menu[i]).setPreferredWidth(menuWidth[i]);
+        }
+        ((JComponent) table.getDefaultRenderer(Boolean.class)).setOpaque(true);
+        table.addMouseListener(tableAction);
+		table.setRowHeight(FontManager.getInstance().getUIFontHeight(table));
+
+        table.setRowSorter(sorter);
+        table.setModel(option_model);
+
+        CustomScrollPane scrollpane1 = new CustomScrollPane();
+        scrollpane1.setViewportView(table);
+        scrollpane1.setBackground(Color.WHITE);
+        scrollpane1.setMinimumSize(new Dimension(800, 150));
+        scrollpane1.setMaximumSize(new Dimension(800, 150));
+        scrollpane1.setAlignmentY(Component.TOP_ALIGNMENT);
+
+        main_panel.add(createTableButton(addAction, editAction, removeAction));
+        main_panel.add(scrollpane1);
+        main_panel.setBackground(Color.WHITE);
+        main_panel.setMaximumSize(new Dimension(Short.MAX_VALUE, main_panel.getMinimumSize().height));
+
+        return main_panel;
+    }
+
+    private JPanel createTableButton(ActionListener addAction, ActionListener editAction, ActionListener removeAction) {
+        JPanel panel = new JPanel();
+
+        JButton button_add = new JButton("Add");
+        JButton button_edit = new JButton("Edit");
+        JButton button_remove = new JButton("Remove");
+
+        int height = button_add.getMinimumSize().height;
+
+        button_add.setMaximumSize(new Dimension(100, height));
+        button_edit.setMaximumSize(new Dimension(100, height));
+        button_remove.setMaximumSize(new Dimension(100, height));
+
+        if (null != addAction) {
+            panel.add(button_add);
+            button_add.addActionListener(addAction);
+        }
+        if (null != editAction) {
+            panel.add(button_edit);
+            button_edit.addActionListener(editAction);
+        }
+        if (null != removeAction) {
+            panel.add(button_remove);
+            button_remove.addActionListener(removeAction);
+        }
+
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.setBackground(Color.WHITE);
+        panel.setMaximumSize(new Dimension(100, panel.getMinimumSize().height));
+        panel.setAlignmentY(Component.TOP_ALIGNMENT);
+        return panel;
+    }
+
+    protected RegexParam getSelectedTableContent() {
+        return getTableContent(table.getSelectedRow());
+    }
+
+    protected RegexParam getTableContent(int rowIndex) {
+        return regexParams.get(rowIndex);
+    }
+}

--- a/src/main/java/core/packetproxy/gui/GUIRegexParamsTableDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIRegexParamsTableDialog.java
@@ -178,7 +178,6 @@ public class GUIRegexParamsTableDialog extends JDialog {
 
         main_panel.add(createTableButton(addAction, editAction, removeAction));
         main_panel.add(scrollpane1);
-        main_panel.setBackground(Color.WHITE);
         main_panel.setMaximumSize(new Dimension(Short.MAX_VALUE, main_panel.getMinimumSize().height));
 
         return main_panel;
@@ -211,7 +210,6 @@ public class GUIRegexParamsTableDialog extends JDialog {
         }
 
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
-        panel.setBackground(Color.WHITE);
         panel.setMaximumSize(new Dimension(100, panel.getMinimumSize().height));
         panel.setAlignmentY(Component.TOP_ALIGNMENT);
         return panel;

--- a/src/main/java/core/packetproxy/model/RegexParam.java
+++ b/src/main/java/core/packetproxy/model/RegexParam.java
@@ -1,0 +1,84 @@
+package packetproxy.model;
+
+import java.nio.charset.Charset;
+
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
+
+import packetproxy.util.CharSetUtility;
+
+public class RegexParam {
+    private int packetId;
+    private String name;
+    private Pattern regex;
+    private String value;
+
+    public RegexParam(int packetId, String name, String regex) {
+        this.packetId = packetId;
+        this.name = name;
+        this.regex = Pattern.compile(regex);
+        this.value = "";
+    }
+
+    public int getPacketId() {
+        return this.packetId;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public String getRegex() {
+        return this.regex.pattern();
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public void setValue(OneShotPacket oneshot) {
+        byte[] dataByte = oneshot.getData();
+        CharSetUtility charSetUtility = CharSetUtility.getInstance();
+        String encoding = charSetUtility.guessCharSetFromHttpHeader(dataByte);
+        if (encoding == "") {
+            encoding = charSetUtility.guessCharSetFromMetatag(dataByte);
+        }
+        if (encoding == "") {
+            encoding = "utf-8";
+        }
+
+        String data = new String(dataByte, Charset.forName(encoding));
+        Matcher matcher = this.regex.matcher(data);
+        if (matcher.find()) {
+            this.value = matcher.group(1);
+        }
+    }
+
+    public OneShotPacket applyToPacket(OneShotPacket oneshot) throws Exception {
+        byte[] data = oneshot.getData();
+        CharSetUtility charSetUtility = CharSetUtility.getInstance();
+        String encoding =  charSetUtility.guessCharSetFromHttpHeader(data);
+        if (encoding == "") {
+            charSetUtility.guessCharSetFromMetatag(data);
+        }
+        if (encoding == "") {
+            encoding = "utf-8";
+        }
+
+        String dataStr = new String(data, Charset.forName(encoding));
+        Pattern pat = Pattern.compile("\\$\\{" + this.name + "\\}\\$");
+        Matcher matcher = pat.matcher(dataStr);
+        if (matcher.find()) {
+            dataStr = matcher.replaceAll(this.value);
+        }
+
+        data = dataStr.getBytes(encoding);
+        oneshot.setData(data);
+
+        return oneshot;
+    }
+}


### PR DESCRIPTION
bulksenderに以下機能を追加しました。

- 送信パケットの一覧にて右クリックをすることで「変数一覧」を表示できるように。「変数」は以下の情報を持ちます
  - 対象パケットID: 表示の際に右クリックしたパケットIDをそのまま保存し、変数抽出時のパケットIDを記録します
  - 抽出用正規表現: 対象パケットIDと一致するパケットのレスポンスをこの正規表現にかけて、マッチした結果を値として保持します。
  - 変数名: 正規表現抽出後、新しく送信するパケットに`${var_name}$`という文字列があった場合、それを抽出した値で置換します。その際の識別子です。
- 上記「変数」が存在する場合、bulksenderは全パケットを一斉に再送信せず、ID順に逐次送信を行います。