### PR TITLE
gRPC-webモジュールが特定のContent-Typeの値の場合に機能しない問題を修正

### DIFF
--- a/src/main/java/core/packetproxy/encode/EncodeGRPCWeb.java
+++ b/src/main/java/core/packetproxy/encode/EncodeGRPCWeb.java
@@ -34,10 +34,10 @@ public class EncodeGRPCWeb extends EncodeHTTPBase
         var contentType = inputHttp.getFirstHeader("Content-Type");
         if (contentType.startsWith("application/grpc-web")) {
             Optional<String> json = Optional.empty();
-            if (contentType.endsWith("web-text+proto")) {
+            if (contentType.endsWith("web-text") || contentType.endsWith("web-text+proto")) {
                 var base64Body = new String(inputHttp.getBody());
                 json = Optional.of(JSON.encode(GRPCMessage.decodeTextMessages(base64Body)));
-            } else if (contentType.endsWith("web+proto")) {
+            } else if (contentType.endsWith("web") || contentType.endsWith("web+proto")) {
                 json = Optional.of(JSON.encode(GRPCMessage.decodeMessages(inputHttp.getBody())));
             }
             json.ifPresent(j -> inputHttp.setBody(j.getBytes()));
@@ -50,9 +50,9 @@ public class EncodeGRPCWeb extends EncodeHTTPBase
         var contentType = inputHttp.getFirstHeader("Content-Type");
         if (contentType.startsWith("application/grpc-web")) {
             List<Map<String, Object>> json = JSON.decode(new String(inputHttp.getBody()));
-            if (contentType.endsWith("web-text+proto")) {
+            if (contentType.endsWith("web-text") || contentType.endsWith("web-text+proto")) {
                 inputHttp.setBody(GRPCMessage.encodeTextMessages(json).getBytes());
-            } else if (contentType.endsWith("web+proto")) {
+            } else if (contentType.endsWith("web") || contentType.endsWith("web+proto")) {
                 inputHttp.setBody(GRPCMessage.encodeMessages(json));
             }
         }
@@ -64,10 +64,10 @@ public class EncodeGRPCWeb extends EncodeHTTPBase
         var contentType = inputHttp.getFirstHeader("Content-Type");
         if (contentType.startsWith("application/grpc-web")) {
             Optional<String> json = Optional.empty();
-            if (contentType.endsWith("web-text+proto")) {
+            if (contentType.endsWith("web-text") || contentType.endsWith("web-text+proto")) {
                 var base64Body = new String(inputHttp.getBody());
                 json = Optional.of(JSON.encode(GRPCMessage.decodeTextMessages(base64Body)));
-            } else if (contentType.endsWith("web+proto")) {
+            } else if (contentType.endsWith("web") || contentType.endsWith("web+proto")) {
                 json = Optional.of(JSON.encode(GRPCMessage.decodeMessages(inputHttp.getBody())));
             }
             json.ifPresent(j -> inputHttp.setBody(j.getBytes()));
@@ -80,9 +80,9 @@ public class EncodeGRPCWeb extends EncodeHTTPBase
         var contentType = inputHttp.getFirstHeader("Content-Type");
         if (contentType.startsWith("application/grpc-web")) {
             List<Map<String, Object>> json = JSON.decode(new String(inputHttp.getBody()));
-            if (contentType.endsWith("web-text+proto")) {
+            if (contentType.endsWith("web-text") || contentType.endsWith("web-text+proto")) {
                 inputHttp.setBody(GRPCMessage.encodeTextMessages(json).getBytes());
-            } else if (contentType.endsWith("web+proto")) {
+            } else if (contentType.endsWith("web") || contentType.endsWith("web+proto")) {
                 inputHttp.setBody(GRPCMessage.encodeMessages(json));
             }
         }


### PR DESCRIPTION
gRPC-web モジュールにおいて、以下の Content-Type の値の場合にデコード/エンコード機能が動作しなくなっていた問題を修正しました。

```
application/grpc-web
application/grpc-web-text
```

症状再現の例として、[gRPC-web 公式サンプルの echo サーバ](https://grpc.io/docs/platforms/web/quickstart/#run-an-echo-example-from-your-browser)では Content-Type に `application/grpc-web-text` が使用されますが、現バージョンの PacketProxy 2.1.9 では、その通信を gRPC-web モジュールで拾ってもデコード/エンコード機能が動作しません。

[gRPC 公式ドキュメントのContent-Typeに関する記述](https://github.com/grpc/grpc/blob/d8f98fb1a76d88fa65e3648a0e38b5872e1df07c/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2)では、以下のようにメッセージ形式の指定（`+proto` など）がない場合は、受信者側は `+proto` であると想定する必要があるとの記載があります。今回はその仕様に沿った修正となります。

>the receiver should assume the default is "+proto" when the message format is missing in Content-Type (as "application/grpc-web")

Java の開発環境が整っておらず簡易的な修正となって申し訳ないのですが…。ご確認お願いします。

[x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
