### PR TITLE
Extension機能の追加・RandomnessCheckerのExtensionへの移行

### DIFF
--- a/src/main/java/core/packetproxy/EncoderManager.java
+++ b/src/main/java/core/packetproxy/EncoderManager.java
@@ -140,6 +140,16 @@ public class EncoderManager
 		}
 	}
 
+	public void addEncoder(String name, Class klass) {
+		if (Encoder.class.isAssignableFrom(klass)) {
+			module_list.put(name, klass);
+		}
+	}
+
+	public void removeEncoder(String name) {
+		module_list.remove(name);
+	}
+
 	public boolean hasDuplicateModules(){
 		return isDuplicated;
 	}

--- a/src/main/java/core/packetproxy/extensions/randomness/RandomnessExtension.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/RandomnessExtension.java
@@ -102,11 +102,6 @@ public class RandomnessExtension extends Extension {
     }
 
     @Override
-    public void setName(String s) {
-        super.setName(s);
-    }
-
-    @Override
     public JComponent createPanel() throws Exception {
         JSplitPane vsplit_panel = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         vsplit_panel.add(createSendPanel());

--- a/src/main/java/core/packetproxy/extensions/randomness/RandomnessExtension.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/RandomnessExtension.java
@@ -41,6 +41,7 @@ import java.io.UnsupportedEncodingException;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -88,11 +89,15 @@ public class RandomnessExtension extends Extension {
 
     public RandomnessExtension() {
         super();
+        recvPackets = new HashMap<>();
+        tokens = new ArrayList<>();
         this.setName("Randomness");
     }
 
     public RandomnessExtension(String name, String path) throws Exception {
         super(name, path);
+        recvPackets = new HashMap<>();
+        tokens = new ArrayList<>();
         this.setName("Randomness");
     }
 
@@ -103,7 +108,6 @@ public class RandomnessExtension extends Extension {
 
     @Override
     public JComponent createPanel() throws Exception {
-        System.out.println("OK: createPanel");
         JSplitPane vsplit_panel = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         vsplit_panel.add(createSendPanel());
         vsplit_panel.add(createResultPanel());
@@ -422,7 +426,6 @@ public class RandomnessExtension extends Extension {
 
     @Override
     public JMenuItem historyClickHandler() {
-        System.out.println("OK: historyClickHandler");
         JMenuItem randomness = createMenuItem ("send to Randomness Checker", -1, null, new ActionListener() {
             public void actionPerformed(ActionEvent actionEvent) {
                 try {

--- a/src/main/java/core/packetproxy/extensions/randomness/test/ApproximateEntropyTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/ApproximateEntropyTest.java
@@ -1,4 +1,7 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
+
+// source code is from: NIST SP 800-22 rev1-a
+// https://www.nist.gov/disclaimer
 
 import org.apache.commons.math3.distribution.GammaDistribution;
 
@@ -47,7 +50,7 @@ public class ApproximateEntropyTest extends RandomnessTest {
                     int idx = (int)Math.pow(2, blockSize) - 1;
                     for (int j = 0; j < Math.pow(2, blockSize); j++,idx++) {
                         if (P[idx] > 0) {
-                            sum += P[idx] * Math.log(P[idx] / numOfBlocks); 
+                            sum += P[idx] * Math.log(P[idx] / numOfBlocks);
                         }
                     }
                     sum /= numOfBlocks;

--- a/src/main/java/core/packetproxy/extensions/randomness/test/CUsUMTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/CUsUMTest.java
@@ -1,4 +1,4 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
 
 // source code is from: NIST SP 800-22 rev1-a
 // https://www.nist.gov/disclaimer
@@ -12,7 +12,7 @@ public class CUsUMTest extends RandomnessTest {
     public CUsUMTest(int mode) {
         this.mode = mode;
     }
- 
+
     public double[] run(Integer[][] e) {
         int n = 0;
         for (int i = 0; i < e.length; i++) {
@@ -64,5 +64,5 @@ public class CUsUMTest extends RandomnessTest {
             p[j] = 1.0 - sum1 + sum2;
         }
         return p;
-    } 
+    }
 }

--- a/src/main/java/core/packetproxy/extensions/randomness/test/FrequencyTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/FrequencyTest.java
@@ -1,4 +1,4 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
 // source code is from: NIST SP 800-22 rev1-a
 // https://www.nist.gov/disclaimer
 
@@ -23,5 +23,5 @@ public class FrequencyTest extends RandomnessTest {
             p[i] = 1.0 - Erf.erf(z / Math.sqrt(2));
         }
         return p;
-    }    
+    }
 }

--- a/src/main/java/core/packetproxy/extensions/randomness/test/LinearComplexityTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/LinearComplexityTest.java
@@ -1,4 +1,6 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
+// source code is from: NIST SP 800-22 rev1-a
+// https://www.nist.gov/disclaimer
 
 import org.apache.commons.math3.distribution.GammaDistribution;
 
@@ -16,7 +18,7 @@ public class LinearComplexityTest extends RandomnessTest {
     public double[] run(Integer[][] e) {
         int N = e.length / M;
         if (N == 0) {
-            PacketProxyUtility.getInstance().packetProxyLog("[Warn] bit length is not suitable for Rank test. Please collect more tokens."); 
+            PacketProxyUtility.getInstance().packetProxyLog("[Warn] bit length is not suitable for Rank test. Please collect more tokens.");
             return new double[e.length > 0 ? e[0].length : 0];
         }
 
@@ -67,7 +69,7 @@ public class LinearComplexityTest extends RandomnessTest {
 
                 int sign = (M % 2 == 1 ? -1 : 1);
                 double mean = M / 2.0 + (9.0 + sign) / 36.0 - 1.0 / Math.pow(2, M) * (M / 3.0 + 2.0 / 9.0);
-                
+
                 sign = (M % 2 == 0 ? 1 : -1);
                 double tmpT = sign * (L - mean) + 2.0 / 9.0;
 
@@ -90,12 +92,12 @@ public class LinearComplexityTest extends RandomnessTest {
 
             double chi2 = 0.00;
             for (int j = 0; j <= K; j++) {
-                chi2 += Math.pow(nu[j] - N * pi[j], 2) / (N * pi[j]); 
+                chi2 += Math.pow(nu[j] - N * pi[j], 2) / (N * pi[j]);
             }
             GammaDistribution dist = new GammaDistribution(K / 2.0, 1);
             p[i] = 1 - dist.cumulativeProbability(chi2 / 2.0);
         }
-        
+
         return p;
-    }    
+    }
 }

--- a/src/main/java/core/packetproxy/extensions/randomness/test/LongestRunOfOneTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/LongestRunOfOneTest.java
@@ -1,4 +1,6 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
+// source code is from: NIST SP 800-22 rev1-a
+// https://www.nist.gov/disclaimer
 
 import org.apache.commons.math3.distribution.GammaDistribution;
 
@@ -8,7 +10,7 @@ public class LongestRunOfOneTest extends RandomnessTest {
     public double[] run(Integer[][] e) {
         int n = e.length;
         if (n < 128) {
-            PacketProxyUtility.getInstance().packetProxyLog("[Warn] bit length is not suitable for LongestRunOfOne test. Please collect more tokens."); 
+            PacketProxyUtility.getInstance().packetProxyLog("[Warn] bit length is not suitable for LongestRunOfOne test. Please collect more tokens.");
             return new double[e.length > 0 ? e[0].length : 0];
         }
         int K = 0, M = 0;
@@ -53,7 +55,7 @@ public class LongestRunOfOneTest extends RandomnessTest {
                         r = 0;
                     }
                 }
-                
+
                 if (Vb < V[0]) {
                     nu[0]++;
                 }
@@ -75,5 +77,4 @@ public class LongestRunOfOneTest extends RandomnessTest {
         }
         return p;
     }
-}    
-
+}

--- a/src/main/java/core/packetproxy/extensions/randomness/test/RandomnessTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/RandomnessTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.extensions.randomness.test;
+
+abstract public class RandomnessTest {
+    // e[i][j] should be in {0, 1}
+    // return: p-value of each bit
+    abstract public double[] run(Integer[][] e);
+}
+

--- a/src/main/java/core/packetproxy/extensions/randomness/test/RandomnessTestManager.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/RandomnessTestManager.java
@@ -1,4 +1,19 @@
-package packetproxy.randomness;
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.extensions.randomness.test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -9,8 +24,8 @@ import javax.swing.JComboBox;
 
 public class RandomnessTestManager {
     private static RandomnessTestManager instance;
-    private Map<String, RandomnessTest> testMap = new HashMap<String, RandomnessTest>();
-    private double[] x;
+    private final Map<String, RandomnessTest> testMap = new HashMap<>();
+    private final double[] x;
 
     public static RandomnessTestManager getInstance() {
         if (instance == null) {
@@ -37,7 +52,7 @@ public class RandomnessTestManager {
 
         testList.addItem("LongestRunOfOne");
         testMap.put("LongestRunOfOne", new LongestRunOfOneTest());
-        
+
         testList.addItem("MatrixRank");
         testMap.put("MatrixRank", new RankTest());
 
@@ -72,8 +87,8 @@ public class RandomnessTestManager {
 
             for (int i = 0; i < res.length; i++) {
                 int cnt = 0;
-                for (int j = 0; j < pValues.length; j++) {
-                    if (x[i] > pValues[j]) cnt++;
+                for (double pValue : pValues) {
+                    if (x[i] > pValue) cnt++;
                 }
                 res[i][0] = x[i];
                 res[i][1] = cnt;

--- a/src/main/java/core/packetproxy/extensions/randomness/test/RankTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/RankTest.java
@@ -1,4 +1,6 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
+// source code is from: NIST SP 800-22 rev1-a
+// https://www.nist.gov/disclaimer
 
 import org.apache.commons.math3.distribution.GammaDistribution;
 import org.ejml.simple.SimpleMatrix;
@@ -10,7 +12,7 @@ public class RankTest extends RandomnessTest {
     public double[] run(Integer[][] e) {
         int N = e.length / (32 * 32);
         if (N == 0) {
-            PacketProxyUtility.getInstance().packetProxyLog("[Warn] bit length is not suitable for Rank test. Please collect more tokens."); 
+            PacketProxyUtility.getInstance().packetProxyLog("[Warn] bit length is not suitable for Rank test. Please collect more tokens.");
             return new double[e.length > 0 ? e[0].length : 0];
         }
 
@@ -20,7 +22,7 @@ public class RankTest extends RandomnessTest {
         }
 
         double[] p = new double[n];
-        for (int i = 0 ; i < n; i++) {  
+        for (int i = 0 ; i < n; i++) {
             SimpleMatrix mat = new SimpleMatrix(32, 32);
 
             int r = 32;
@@ -29,7 +31,7 @@ public class RankTest extends RandomnessTest {
                 product *= (1.0 - Math.pow(2, j - 32)) * (1 - Math.pow(2, j - 32)) / (1 - Math.pow(2, j - r));
             }
             double p32 = Math.pow(2, r * (32 + 32 - r) - 32 * 32) * product;
-            
+
             r = 31;
             product = 1;
             for (int j = 0; j < r; j++) {
@@ -48,22 +50,22 @@ public class RankTest extends RandomnessTest {
                 }
                 SimpleSVD<SimpleMatrix> svd = mat.svd();
                 switch(svd.rank()) {
-                case 32:
-                    F32++;
-                    break;
-                case 31:
-                    F31++;
+                    case 32:
+                        F32++;
+                        break;
+                    case 31:
+                        F31++;
                 }
             }
             double F30 = N - (F32 + F31);
 
             double chiSquared = Math.pow(F32 - N * p32, 2) / (N * p32) +
-                Math.pow(F31 - N * p31, 2) / (N * p31) +
-                Math.pow(F30 - N * p30, 2) / (N * p30);
-            
+                    Math.pow(F31 - N * p31, 2) / (N * p31) +
+                    Math.pow(F30 - N * p30, 2) / (N * p30);
+
             GammaDistribution dist = new GammaDistribution(N / 2.0, 1);
             p[i] = 1 - dist.cumulativeProbability(chiSquared / 2.0);
         }
         return p;
-    } 
+    }
 }

--- a/src/main/java/core/packetproxy/extensions/randomness/test/RunsTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/RunsTest.java
@@ -1,4 +1,6 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
+// source code is from: NIST SP 800-22 rev1-a
+// https://www.nist.gov/disclaimer
 
 import org.apache.commons.math3.special.Erf;
 
@@ -25,5 +27,5 @@ public class RunsTest extends RandomnessTest {
             p[i] = Erf.erfc(erfcArgs);
         }
         return p;
-    } 
+    }
 }

--- a/src/main/java/core/packetproxy/extensions/randomness/test/SerialTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/SerialTest.java
@@ -1,4 +1,6 @@
-package packetproxy.randomness;
+package packetproxy.extensions.randomness.test;
+// source code is from: NIST SP 800-22 rev1-a
+// https://www.nist.gov/disclaimer
 
 import org.apache.commons.math3.distribution.GammaDistribution;
 
@@ -23,7 +25,7 @@ public class SerialTest extends RandomnessTest {
 
             double del1 = pSim0 - pSim1;
             double del2 = pSim0 - 2.0 * pSim1 + pSim2;
-            
+
             GammaDistribution dist = new GammaDistribution(Math.abs(del1 / 2.0), 1);
             double p1 = 1 - dist.cumulativeProbability(Math.pow(2, M - 1));
             dist = new GammaDistribution(Math.abs(del2 / 2.0), 1);

--- a/src/main/java/core/packetproxy/extensions/samplehttp/SampleEncoders.java
+++ b/src/main/java/core/packetproxy/extensions/samplehttp/SampleEncoders.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.extensions.samplehttp;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import packetproxy.extensions.samplehttp.encoder.SampleHTTP;
+import packetproxy.model.Extension;
+
+public class SampleEncoders extends Extension {
+    public SampleEncoders() {
+        super();
+        this.setName("Sample Extension Encoders");
+    }
+
+    public SampleEncoders(String name, String path) throws Exception {
+        super(name, path);
+        this.setName("Sample Extension Encoders");
+    }
+
+    @Override
+    public Map<String, Class<?>> getEncoders() {
+        return new HashMap<String, Class<?>>(){{
+            put("SampleHTTP from extension", SampleHTTP.class);
+        }};
+    }
+}

--- a/src/main/java/core/packetproxy/extensions/samplehttp/encoder/SampleHTTP.java
+++ b/src/main/java/core/packetproxy/extensions/samplehttp/encoder/SampleHTTP.java
@@ -1,0 +1,35 @@
+package packetproxy.extensions.samplehttp.encoder;
+
+import packetproxy.encode.EncodeHTTPBase;
+import packetproxy.http.Http;
+
+public class SampleHTTP extends EncodeHTTPBase {
+    public SampleHTTP(String ALPN) throws Exception {
+        super(ALPN);
+    }
+
+    @Override
+    public String getName() {
+        return "SampleHTTP from extension";
+    }
+
+    @Override
+    protected Http decodeClientRequestHttp(Http inputHttp) throws Exception {
+        return inputHttp;
+    }
+
+    @Override
+    protected Http encodeClientRequestHttp(Http inputHttp) throws Exception {
+        return inputHttp;
+    }
+
+    @Override
+    protected Http decodeServerResponseHttp(Http inputHttp) throws Exception {
+        return inputHttp;
+    }
+
+    @Override
+    protected Http encodeServerResponseHttp(Http inputHttp) throws Exception {
+        return inputHttp;
+    } 
+}

--- a/src/main/java/core/packetproxy/gui/GUIExtensions.java
+++ b/src/main/java/core/packetproxy/gui/GUIExtensions.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.gui;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import packetproxy.model.Extension;
+import packetproxy.model.Extensions;
+
+public class GUIExtensions {
+    private static GUIExtensions instance;
+    private static JFrame owner;
+    private JPanel main_panel;
+    private JTabbedPane tabs;
+    private int previousTabIndex;
+    // relations between extension name and menu index
+    private Map<String, JMenuItem> extensionMenus;
+
+    public static JFrame getOwner() {
+        return owner;
+    }
+
+    public static GUIExtensions getInstance() throws Exception {
+        if (instance == null) {
+            instance = new GUIExtensions();
+        }
+        return instance;
+    }
+
+    private GUIExtensions() throws Exception {
+        extensionMenus = new HashMap<>();
+        File directory = new File(System.getProperty("user.home") + "/.packetproxy/extensions");
+        File[] jarFiles = directory.listFiles(new FilenameFilter() {
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".jar");
+            }
+        });
+        URL[] urls = new URL[jarFiles.length];
+        for (int i = 0; i < jarFiles.length; i++) {
+            urls[i] = jarFiles[i].toURI().toURL();
+        }
+        URLClassLoader urlClassLoader = new URLClassLoader(urls);
+        for (File jarFile : jarFiles) {
+            JarFile jar = new JarFile(jarFile);
+            for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements();) {
+                JarEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (!name.endsWith(".class"))   continue;
+
+                String className = name.replace("/", ".").substring(0, name.length() - 6);
+                Class clazz = urlClassLoader.loadClass(className);
+                if (!Extension.class.isAssignableFrom(clazz))   continue;
+                Constructor constructor = clazz.getConstructor();
+                Extension ext = (Extension)constructor.newInstance();
+                if (ext.getName() == null) {
+                    ext.setName(className);
+                }
+                if (ext.getPath() == null) {
+                    ext.setPath(jarFile.toPath().toString());
+                }
+                Extensions.getInstance().create(ext);
+            }
+            jar.close();
+        }
+        urlClassLoader.close();
+
+        main_panel = new JPanel();
+        tabs = new JTabbedPane();
+
+        System.out.println("GUIExtensions loading start");
+        for (Extension extension: Extensions.getInstance().queryAll()) {
+            System.out.println(extension.getName() + " " + extension.isEnabled());
+            if (extension.isEnabled()) {
+                tabs.addTab(extension.getName(), extension.createPanel());
+            }
+        }
+        System.out.println("GUIExtensions loading finished");
+
+        tabs.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                int currentTabIndex = tabs.getSelectedIndex();
+                previousTabIndex = currentTabIndex;
+            }
+        });
+        main_panel.setLayout(new BoxLayout(main_panel, BoxLayout.Y_AXIS));
+        main_panel.add(tabs);
+    }
+
+    public void addExtension(Extension ext) throws Exception {
+        tabs.addTab(ext.getName(), ext.createPanel());
+
+        JMenuItem extensionItem = ext.historyClickHandler();
+        if (extensionItem != null) {
+            GUIHistory.getInstance().addMenu(extensionItem);
+            extensionMenus.put(ext.getName(), extensionItem);
+        }
+    }
+
+    public void removeExtension(Extension ext) throws Exception {
+        JMenuItem extensionItem = extensionMenus.get(ext.getName());
+        if (extensionItem != null) {
+            GUIHistory.getInstance().removeMenu(extensionItem);
+            extensionMenus.remove(ext.getName());
+        }
+
+        int index = tabs.indexOfTab(ext.getName());
+        if (index >= 0) {
+            tabs.removeTabAt(index);
+        }
+    }
+
+    public JComponent createPanel() throws Exception {
+        return main_panel;
+    }
+}

--- a/src/main/java/core/packetproxy/gui/GUIHistory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistory.java
@@ -132,6 +132,7 @@ public class GUIHistory implements Observer
 	private Hashtable<Integer, Integer> id_row;
 	private boolean dialogOnce = false;
 	private GUIHistoryAutoScroll autoScroll;
+	private JPopupMenu menu;
 
 	private GUIHistory(boolean restore) throws Exception {
 		packets = Packets.getInstance(restore);
@@ -386,7 +387,7 @@ public class GUIHistory implements Observer
 		if (!PacketProxyUtility.getInstance().isMac()) {
 			mask_key = ActionEvent.CTRL_MASK;
 		}
-		JPopupMenu menu = new JPopupMenu();
+		menu = new JPopupMenu();
 
 		JMenuItem send = createMenuItem ("send", KeyEvent.VK_S, KeyStroke.getKeyStroke(KeyEvent.VK_S, mask_key), new ActionListener() {
 			public void actionPerformed(ActionEvent actionEvent) {
@@ -463,16 +464,6 @@ public class GUIHistory implements Observer
 			public void actionPerformed(ActionEvent actionEvent) {
 				try {
 					GUIBulkSender.getInstance().add(gui_packet.getPacket().getOneShotFromModifiedData(), gui_packet.getPacket().getId());
-				} catch (Exception e) {
-					e.printStackTrace();
-				}
-			}
-		});
-
-		JMenuItem randomness = createMenuItem ("send to Randomness Checker", -1, null, new ActionListener() {
-			public void actionPerformed(ActionEvent actionEvent) {
-				try {
-					GUIRandomness.getInstance().add(gui_packet.getPacket().getOneShotFromModifiedData(), gui_packet.getPacket().getId());
 				} catch (Exception e) {
 					e.printStackTrace();
 				}
@@ -685,7 +676,6 @@ TODO: support --data-binary
 		menu.add(copyAll);
 		menu.add(copy);
 		menu.add(bulkSender);
-		menu.add(randomness);
 		menu.add(saveAll);
 		menu.add(saveHttpBody);
 		menu.add(addColorG);
@@ -696,7 +686,6 @@ TODO: support --data-binary
 		menu.add(delete_selected_items);
 		menu.add(delete_all);
 
-		
 		table.addKeyListener(new KeyAdapter() {
 			public void keyPressed(KeyEvent e) {
 				try {
@@ -1124,5 +1113,13 @@ TODO: support --data-binary
 	}
 	public int getSelectedIndex() {
 		return table.getSelectedRow();
+	}
+
+	public void addMenu(JMenuItem menuItem) {
+		menu.add(menuItem);
+	}
+
+	public void removeMenu(JMenuItem menuItem) {
+		menu.remove(menuItem);
 	}
 }

--- a/src/main/java/core/packetproxy/gui/GUIMain.java
+++ b/src/main/java/core/packetproxy/gui/GUIMain.java
@@ -46,11 +46,11 @@ public class GUIMain extends JFrame implements Observer
 	private GUIIntercept gui_intercept;
 	private GUIRepeater gui_repeater;
 	private GUIBulkSender gui_bulksender;
-	private GUIRandomness gui_randomness;
+	private GUIExtensions gui_extensions;
 	private GUIVulCheckHelper gui_vulcheckhelper;
 	private GUILog gui_log;
 	private InterceptModel interceptModel;
-	public enum Panes {HISTORY, INTERCEPT, REPEATER, VULCHECKHELPER, BULKSENDER, RANDOMNESS, OPTIONS, LOG};
+	public enum Panes {HISTORY, INTERCEPT, REPEATER, VULCHECKHELPER, BULKSENDER, EXTENSIONS, OPTIONS, LOG};
 
 	public static GUIMain getInstance(String title) throws Exception
 	{
@@ -85,8 +85,8 @@ public class GUIMain extends JFrame implements Observer
 			return "VulCheck Helper";
 		case BULKSENDER:
 			return "Bulk Sender";
-		case RANDOMNESS:
-			return "Randomness Checker";
+		case EXTENSIONS:
+			return "Extensions";
 		case OPTIONS:
 			return "Options";
 		case LOG:
@@ -110,7 +110,7 @@ public class GUIMain extends JFrame implements Observer
 			gui_intercept = new GUIIntercept(this);
 			gui_repeater = GUIRepeater.getInstance();
 			gui_bulksender = GUIBulkSender.getInstance();
-			gui_randomness = GUIRandomness.getInstance();
+			gui_extensions = GUIExtensions.getInstance();
 			gui_vulcheckhelper = GUIVulCheckHelper.getInstance();
 			gui_log = GUILog.getInstance();
 
@@ -120,7 +120,7 @@ public class GUIMain extends JFrame implements Observer
 			tabbedpane.addTab(getPaneString(Panes.REPEATER), gui_repeater.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.VULCHECKHELPER), gui_vulcheckhelper.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.BULKSENDER), gui_bulksender.createPanel());
-			tabbedpane.addTab(getPaneString(Panes.RANDOMNESS), gui_randomness.createPanel());
+			tabbedpane.addTab(getPaneString(Panes.EXTENSIONS), gui_extensions.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.OPTIONS), gui_option.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.LOG), gui_log.createPanel());
 

--- a/src/main/java/core/packetproxy/gui/GUIOption.java
+++ b/src/main/java/core/packetproxy/gui/GUIOption.java
@@ -247,6 +247,12 @@ public class GUIOption
 
 		panel.add(createSeparator());
 
+		panel.add(createElement("Extensions", I18nString.get("Enable/Disable loaded extensions")));
+		GUIOptionExtensions extensionsGUI = new GUIOptionExtensions(owner);
+		panel.add(extensionsGUI.createPanel());
+
+		panel.add(createSeparator());
+
 		panel.add(createElement("Fonts", ""));
 		GUIOptionFonts fontsGUI = new GUIOptionFonts(owner);
 		panel.add(fontsGUI.createPanel());

--- a/src/main/java/core/packetproxy/gui/GUIOptionExtensions.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionExtensions.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.gui;
+
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JFrame;
+
+import packetproxy.model.Extension;
+import packetproxy.model.Extensions;
+
+public class GUIOptionExtensions extends GUIOptionComponentBase<Extension> {
+    Extensions extensions;
+    List<Extension> table_ext_list;
+
+    public GUIOptionExtensions(JFrame owner) throws Exception {
+        super(owner);
+        extensions = Extensions.getInstance();
+        extensions.addObserver(this);
+        table_ext_list = new ArrayList<Extension>();
+
+        String[] menu = { "Enabled", "Name", "Path" };
+        int[] menuWidth = { 30, 300, 300 };
+        MouseAdapter tableAction = new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				try {
+                    int columnIndex = table.columnAtPoint(e.getPoint());
+                    int rowIndex = table.rowAtPoint(e.getPoint());
+                    if (columnIndex == 0) { /* check box area */
+                        boolean enable_checkbox = (Boolean) table.getValueAt(rowIndex, 0);
+                        Extension ext = getSelectedTableContent();
+                        ext.setEnabled(!enable_checkbox);
+                        ext = extensions.update(ext);
+                        if (!enable_checkbox && ext != null) {
+                            GUIExtensions.getInstance().addExtension(ext);
+                        } else if (enable_checkbox) {
+                            GUIExtensions.getInstance().removeExtension(ext);
+                        }
+                    }
+                    table.setRowSelectionInterval(rowIndex, columnIndex);
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+        ActionListener addAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    GUIOptionExtensionsDialog dlg = new GUIOptionExtensionsDialog(owner);
+                    Extension ext = dlg.showDialog();
+                    if (ext != null) {
+                        Extensions.getInstance().create(ext);
+                    }
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+        ActionListener editAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    Extension old_ext = getSelectedTableContent();
+                    GUIOptionExtensionsDialog dlg = new GUIOptionExtensionsDialog(owner);
+                    Extension ext = dlg.showDialog(old_ext);
+                    if (ext != null && (ext.getName() != old_ext.getName() || ext.getPath() != old_ext.getPath())) {
+                        GUIExtensions.getInstance().removeExtension(old_ext);
+                        Extensions.getInstance().delete(old_ext);
+                        Extensions.getInstance().create(ext);
+                    }
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+        ActionListener removeAction = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    GUIExtensions.getInstance().removeExtension(getSelectedTableContent());
+                    Extensions.getInstance().delete(getSelectedTableContent());
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        };
+        jcomponent = createComponent(menu, menuWidth, tableAction, addAction, editAction, removeAction);
+        updateImpl();
+    }
+
+    @Override
+    protected void addTableContent(Extension ext) {
+        table_ext_list.add(ext);
+        try {
+            option_model.addRow(new Object[] {
+                ext.isEnabled(),
+                ext.getName(),
+                ext.getPath(),
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void updateTable(List<Extension> exts) {
+        clearTableContents();
+        for(Extension ext: exts) {
+            addTableContent(ext);
+        }
+    }
+
+    @Override
+    protected void updateImpl() {
+        try {
+            updateTable(extensions.queryAll());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void clearTableContents() {
+        option_model.setRowCount(0);
+        table_ext_list.clear();
+    }
+    @Override
+    protected Extension getSelectedTableContent() {
+        return getTableContent(table.getSelectedRow());
+    }
+    @Override
+    protected Extension getTableContent(int rowIndex) {
+        return table_ext_list.get(rowIndex);
+    }
+}

--- a/src/main/java/core/packetproxy/gui/GUIOptionExtensionsDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionExtensionsDialog.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.gui;
+
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import packetproxy.common.I18nString;
+import packetproxy.model.Extension;
+import packetproxy.model.Extensions;
+
+public class GUIOptionExtensionsDialog extends JDialog {
+    private static final long serialVersionUID = 1L;
+    private JButton button_cancel = new JButton(I18nString.get("Cancel"));
+    private JButton button_set = new JButton(I18nString.get("Save"));
+    private HintTextField nameField = new HintTextField("sample library");
+    private HintTextField pathField = new HintTextField("path/to/library.jar");
+    private int height = 500;
+    private int width = 500;
+    private Extension extension = null;
+
+    private JComponent label_and_object(String label_name, JComponent object) {
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+	    JLabel label = new JLabel(label_name);
+	    label.setPreferredSize(new Dimension(150, label.getMaximumSize().height));
+	    panel.add(label);
+	    object.setMaximumSize(new Dimension(Short.MAX_VALUE, label.getMaximumSize().height * 2));
+	    panel.add(object);
+		return panel;
+    }
+    private JComponent buttons() {
+        JPanel panel_button = new JPanel();
+	    panel_button.setLayout(new BoxLayout(panel_button, BoxLayout.X_AXIS));
+	    panel_button.setMaximumSize(new Dimension(Short.MAX_VALUE, button_set.getMaximumSize().height));
+	    panel_button.add(button_cancel);
+	    panel_button.add(button_set);
+	    return panel_button;
+    }
+    public Extension showDialog(Extension preset) throws Exception {
+        nameField.setText(preset.getName());
+        nameField.setEditable(false);
+        pathField.setText(preset.getPath());
+        setModal(true);
+        setVisible(true);
+        return extension;
+    }
+    public Extension showDialog() {
+        setModal(true);
+        setVisible(true);
+        return extension;
+    }
+    private JComponent createName() throws Exception {
+        return label_and_object(I18nString.get("Library Name"), nameField);
+    }
+    private JComponent createPath() throws Exception {
+        return label_and_object(I18nString.get("Library Path"), pathField);
+    }
+    public GUIOptionExtensionsDialog(JFrame owner) throws Exception {
+        super(owner);
+        setTitle(I18nString.get("Setting"));
+        Rectangle rect = owner.getBounds();
+        setBounds(rect.x + rect.width/2 - width/2, rect.y + rect.height/2 - height/2, width, height);
+
+        Container c = getContentPane();
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.add(createName());
+        panel.add(createPath());
+        panel.add(buttons());
+        c.add(panel);
+        button_set.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    String name = nameField.getText();
+                    String path = pathField.getText();
+                    extension = Extensions.getInstance().loadExtension(name, path);
+                    dispose();
+                } catch (Exception e1) {
+                    e1.printStackTrace();
+                }
+            }
+        });
+        button_cancel.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dispose();
+            }
+        });
+    }
+}

--- a/src/main/java/core/packetproxy/gui/GUIOptionExtensionsDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionExtensionsDialog.java
@@ -99,7 +99,9 @@ public class GUIOptionExtensionsDialog extends JDialog {
                 try {
                     String name = nameField.getText();
                     String path = pathField.getText();
-                    extension = Extensions.getInstance().loadExtension(name, path);
+                    if (name != "") {
+                        extension = Extensions.getInstance().loadExtension(name, path);
+                    }
                     dispose();
                 } catch (Exception e1) {
                     e1.printStackTrace();

--- a/src/main/java/core/packetproxy/model/Extension.java
+++ b/src/main/java/core/packetproxy/model/Extension.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.model;
+
+import javax.swing.JComponent;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+
+@DatabaseTable(tableName = "extensions")
+public class Extension {
+    @DatabaseField(id = true)
+    private String name;
+    @DatabaseField
+    private boolean enabled;
+    @DatabaseField
+    private String path;
+
+    public Extension() {
+        // ORMLite needs a no-arg constructor
+    }
+    public Extension(String name, String path) throws Exception {
+        setEnabled(false);
+        setName(name);
+        setPath(path);
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+    public void setEnabled(boolean e) {
+        this.enabled = e;
+    }
+    public String getName() {
+        return this.name;
+    }
+    public void setName(String s) {
+        this.name = s;
+    }
+    public String getPath() {
+        return this.path;
+    }
+    public void setPath(String s) {
+        this.path = s;
+    }
+
+    public JComponent createPanel() throws Exception {
+        // Please override this
+        System.out.println("NG: createPanel");
+        return new JPanel();
+    }
+    public JMenuItem historyClickHandler() {
+        // Please override this
+        System.out.println("NG: historyClickHandler");
+        return new JMenuItem("extensions");
+    }
+}

--- a/src/main/java/core/packetproxy/model/Extension.java
+++ b/src/main/java/core/packetproxy/model/Extension.java
@@ -61,12 +61,10 @@ public class Extension {
 
     public JComponent createPanel() throws Exception {
         // Please override this
-        System.out.println("NG: createPanel");
         return new JPanel();
     }
     public JMenuItem historyClickHandler() {
         // Please override this
-        System.out.println("NG: historyClickHandler");
         return new JMenuItem("extensions");
     }
 }

--- a/src/main/java/core/packetproxy/model/Extension.java
+++ b/src/main/java/core/packetproxy/model/Extension.java
@@ -15,9 +15,11 @@
  */
 package packetproxy.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
-import javax.swing.JPanel;
 
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
@@ -61,10 +63,14 @@ public class Extension {
 
     public JComponent createPanel() throws Exception {
         // Please override this
-        return new JPanel();
+        return null;
     }
     public JMenuItem historyClickHandler() {
         // Please override this
-        return new JMenuItem("extensions");
+        return null;
+    }
+    public Map<String, Class<?>> getEncoders() {
+        // Please override this
+        return new HashMap<>(); 
     }
 }

--- a/src/main/java/core/packetproxy/model/Extensions.java
+++ b/src/main/java/core/packetproxy/model/Extensions.java
@@ -185,7 +185,6 @@ public class Extensions extends Observable implements Observer {
         Map<String, Extension> newHash = new HashMap<>();
         for (int i = 0; i < ret.size(); i++) {
             Extension ext = ret.get(i);
-            System.out.println("queryAll: " + ext.getName() + " " + ext.isEnabled());
             if (!ext.isEnabled()) continue;
             if (ext_instances.containsKey(ext.getName())) {
                 Extension loadedExt = ext_instances.get(ext.getName());

--- a/src/main/java/core/packetproxy/model/Extensions.java
+++ b/src/main/java/core/packetproxy/model/Extensions.java
@@ -33,6 +33,7 @@ import javax.swing.JOptionPane;
 import com.j256.ormlite.dao.Dao;
 
 import packetproxy.extensions.randomness.RandomnessExtension;
+import packetproxy.extensions.samplehttp.SampleEncoders;
 import packetproxy.model.Database.DatabaseMessage;
 
 public class Extensions extends Observable implements Observer {
@@ -45,8 +46,9 @@ public class Extensions extends Observable implements Observer {
         return instance;
     }
 
-    private static Map<String, Class> presetExtensions = new HashMap<>(){{
+    private static Map<String, Class<?>> presetExtensions = new HashMap<>(){{
         put((new RandomnessExtension()).getName(), RandomnessExtension.class);
+        put((new SampleEncoders()).getName(), SampleEncoders.class);
     }};
 
     // Extensionではなく、継承先のインスタンスを保持する必要がある

--- a/src/main/java/core/packetproxy/randomness/RandomnessTest.java
+++ b/src/main/java/core/packetproxy/randomness/RandomnessTest.java
@@ -1,7 +1,0 @@
-package packetproxy.randomness;
-
-abstract public class RandomnessTest {
-    // e[i][j] should be in {0, 1}
-    // return: p-value of each bit
-    abstract public double[] run(Integer[][] e);
-}


### PR DESCRIPTION
- メインのタブ一覧に「Extensions」が追加されます。
  - Extensionsタブでは、現在有効になっているExtensionの画面を内部タブとして表示できます。例としてRandomnessCheckerを移行していますが、Extensions→Randomnessで表示されます。
- Optionsタブの下方にExtensionの管理UIが追加されます（英語でしか書いていないので日本語記載も入れたほうがいいかもですね）
  - 現時点でのExtension一覧の確認、有効化無効化、及び新しくローカルにある`.jar`形式のファイルをExtensionとして読み込むことも出来ます。
- ExtensionはPacketProxy起動時に`~/.packetproxy/extensions`直下にある`.jar`形式のファイルを読み込みます。しかし上の設定で他の場所にあるファイルを読み込むことも出来ます。
- Extensionを書く際は`packetproxy.model.Extension`をextendsしてください。package名は何でも良いです。
  - `Extension.getName`でExtensionの一意性を記録するため、`getName`は他のExtensionとの重複を避ける必要があります。

Encoderの機能も含むため、https://github.com/DeNA/PacketProxyPlugin と重複する箇所があります。現時点でPacketProxyPluginのリポジトリも存在するため、Pluginをすぐに削除すべきではないと思われます。よって衝突を避けるためPluginではなくExtensionとし、また読み込みディレクトリも変えています。