### PR TITLE
Hostname Resolution Override設定の追加

### DIFF
--- a/src/main/java/core/packetproxy/PrivateDNSClient.java
+++ b/src/main/java/core/packetproxy/PrivateDNSClient.java
@@ -26,7 +26,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
+import packetproxy.model.Resolution;
+import packetproxy.model.Resolutions;
+
 public class PrivateDNSClient {
+
+    private static Resolutions resolutions;
+    private static PacketProxyUtility util;
 
     private static boolean isLoopbackAddress(String addr) {
         return addr.equals("127.0.0.1") ||
@@ -88,6 +94,16 @@ public class PrivateDNSClient {
     }
 
     public static InetAddress getByName(String serverName) throws Exception {
+        resolutions = resolutions.getInstance();
+        util = PacketProxyUtility.getInstance();
+        List<Resolution> resolution_list = resolutions.queryEnabled();
+        for (Resolution resolution : resolution_list) {
+            if (serverName.equals(resolution.getHostName())) {
+                String ip = resolution.getIp();
+                util.packetProxyLog("[Hostname Resolution]: " + serverName + " -> " + ip);
+                return InetAddress.getByName(ip);
+            }
+        }
         return dnsLooping(serverName) ? Address.getByName(serverName) : InetAddress.getByName(serverName);
     }
 

--- a/src/main/java/core/packetproxy/gui/GUIOption.java
+++ b/src/main/java/core/packetproxy/gui/GUIOption.java
@@ -100,6 +100,12 @@ public class GUIOption {
 
 		panel.add(createSeparator());
 
+		panel.add(createElement("Hostname Resolutions", I18nString.get("Set ip addr and server for DNS resolution.")));
+		GUIOptionResolutions resolutions = new GUIOptionResolutions(owner);
+		panel.add(resolutions.createPanel());
+
+		panel.add(createSeparator());
+
 		panel.add(createElement("Auto Modifications", I18nString.get("Set pattern for auto packet modification.")));
 		GUIOptionModifications mods = new GUIOptionModifications(owner);
 		panel.add(mods.createPanel());

--- a/src/main/java/core/packetproxy/gui/GUIOptionResolutionDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionResolutionDialog.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.gui;
+
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JOptionPane;
+
+import java.util.regex.*;
+
+import packetproxy.common.I18nString;
+import packetproxy.model.Resolution;
+
+
+public class GUIOptionResolutionDialog extends JDialog
+{
+	private static final long serialVersionUID = 1L;
+	private JButton button_cancel = new JButton(I18nString.get("Cancel"));
+	private JButton button_set = new JButton(I18nString.get("Save"));
+	private HintTextField text_ip = new HintTextField("(ex.) 127.0.0.1");
+	private HintTextField text_hostname = new HintTextField("(ex.) example.com");
+	private HintTextField text_comment = new HintTextField("(ex.) game server for test");
+	private JCheckBox checkbox_enabled = new JCheckBox(I18nString.get("Override"));
+	private int height = 500;
+	private int width = 700;
+	private Resolution resolution = null;
+
+	private JComponent label_and_object(String label_name, JComponent object) {
+		JPanel panel = new JPanel();
+	    panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+	    JLabel label = new JLabel(label_name);
+	    label.setPreferredSize(new Dimension(150, label.getMaximumSize().height));
+	    panel.add(label);
+	    object.setMaximumSize(new Dimension(Short.MAX_VALUE, label.getMaximumSize().height * 2));
+	    panel.add(object);
+		return panel;
+	}
+	private JComponent buttons() {
+	    JPanel panel_button = new JPanel();
+	    panel_button.setLayout(new BoxLayout(panel_button, BoxLayout.X_AXIS));
+	    panel_button.setMaximumSize(new Dimension(Short.MAX_VALUE, button_set.getMaximumSize().height));
+	    panel_button.add(button_cancel);
+	    panel_button.add(button_set);
+	    return panel_button;
+	}
+	public Resolution showDialog(Resolution preset)
+	{
+   		text_ip.setText(preset.getIp());
+   		text_hostname.setText(preset.getHostName());
+   		checkbox_enabled.setSelected(preset.isEnabled());
+   		text_comment.setText(preset.getComment());
+		setModal(true);
+		setVisible(true);
+		if (resolution != null) {
+			preset.setIp(text_ip.getText());
+			preset.setHostName(text_hostname.getText());
+			preset.setEnabled(checkbox_enabled.isEnabled());
+			preset.setComment(text_comment.getText());
+			return preset;
+		}
+		return resolution;
+	}
+	public Resolution showDialog()
+	{
+		EventQueue.invokeLater(new Runnable() {
+			@Override public void run() {
+				button_cancel.requestFocusInWindow();
+			}
+		});
+		setModal(true);
+		setVisible(true);
+		return resolution;
+	}
+
+	private JComponent createIpSetting() {
+	    return label_and_object(I18nString.get("ip:"), text_ip);
+	}
+	private JComponent createHostNameSetting() {
+	    return label_and_object(I18nString.get("host:"), text_hostname);
+	}
+	private JComponent createEnabledSetting() {
+	    return label_and_object(I18nString.get("enabled:"), checkbox_enabled);
+	}
+	private JComponent createCommentSetting() {
+	    return label_and_object(I18nString.get("Comments:"), text_comment);
+	}
+	public GUIOptionResolutionDialog(JFrame owner) throws Exception {
+		super(owner);
+		setTitle(I18nString.get("Resolution setting"));
+		Rectangle rect = owner.getBounds();
+		setBounds(rect.x + rect.width/2 - width/2, rect.y + rect.height/2 - height/2, width, height); /* ド真ん中 */
+
+		Container c = getContentPane();
+		JPanel panel = new JPanel(); 
+	    panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+	    
+	    panel.add(createIpSetting());
+	    panel.add(createHostNameSetting());
+	    panel.add(createEnabledSetting());
+	    panel.add(createCommentSetting());
+	    
+	    panel.add(buttons());
+
+		c.add(panel);
+
+	    button_cancel.addActionListener(new ActionListener() {
+	    	@Override
+		public void actionPerformed(ActionEvent e) {
+	    		resolution = null;
+	    		dispose();
+	    	}
+	    });
+
+	    button_set.addActionListener(new ActionListener() {
+	    	@Override
+		public void actionPerformed(ActionEvent e) {
+	    		resolution = new Resolution(text_ip.getText(),
+                        text_hostname.getText(),
+	    				checkbox_enabled.isSelected(),
+	    				text_comment.getText());
+	    		dispose();
+	    	}
+	    });
+	}
+}

--- a/src/main/java/core/packetproxy/gui/GUIOptionResolutions.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionResolutions.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.gui;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Observable;
+import java.util.Observer;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTable;
+import javax.swing.table.DefaultTableModel;
+import packetproxy.model.Resolution;
+import packetproxy.model.Resolutions;
+
+public class GUIOptionResolutions extends GUIOptionComponentBase<Resolution>
+{
+	private GUIOptionResolutionDialog dlg;
+	Resolutions resolutions;
+	List<Resolution> table_ext_list;
+
+	public GUIOptionResolutions(JFrame owner) throws Exception {
+		super(owner);
+		this.resolutions = Resolutions.getInstance();
+		this.resolutions.addObserver(this);
+		this.table_ext_list = new ArrayList<Resolution>();
+		String[] menu = { "IP Addr", "Host", "Override", "Comment" };
+		int[] menuWidth = { 200, 200, 50, 100 };
+		
+		MouseAdapter tableAction = new MouseAdapter() {
+			@Override
+			public void mouseClicked(MouseEvent e) {
+				try {
+					int columnIndex= table.columnAtPoint(e.getPoint());
+					int rowIndex= table.rowAtPoint(e.getPoint());
+					if (columnIndex == 2){ /* Override area */
+						boolean enable_checkbox = (Boolean)table.getValueAt(rowIndex, 2);
+						Resolution resolution = getSelectedTableContent();
+						if (enable_checkbox == true) {
+							resolution.disableResolution();
+						} else {
+							resolution.enableResolution();
+						}
+						resolutions.update(resolution);
+					}
+					table.setRowSelectionInterval(rowIndex, rowIndex);
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		};
+		ActionListener addAction = new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				try {
+					dlg = new GUIOptionResolutionDialog(owner);
+					Resolution resolution = dlg.showDialog();
+					resolutions.create(resolution);
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		};
+		ActionListener editAction = new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				try {
+					Resolution old_resolution = getSelectedTableContent();
+					dlg = new GUIOptionResolutionDialog(owner);
+					Resolution new_resolution = dlg.showDialog(old_resolution);
+					if (new_resolution != null) {
+						resolutions.delete(old_resolution);
+						resolutions.create(new_resolution);
+					}
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		};
+		ActionListener removeAction = new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				try {
+					resolutions.delete(getSelectedTableContent());
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		};
+		jcomponent = createComponent(menu, menuWidth, tableAction, addAction, editAction, removeAction);
+		updateImpl();
+	}
+
+	@Override
+	protected void addTableContent(Resolution resolution) {
+		table_ext_list.add(resolution);
+		try {
+			option_model.addRow(new Object[] {
+				resolution.getIp(),
+				resolution.getHostName(),
+				resolution.isEnabled(),
+				resolution.getComment()
+			});
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	protected void updateTable(List<Resolution> resolutionList) {
+		clearTableContents();
+		for (Resolution resolution : resolutionList) {
+			addTableContent(resolution);
+		}
+	}
+
+	@Override
+	protected void updateImpl() {
+		try {
+			updateTable(resolutions.queryAll());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	protected void clearTableContents() {
+		option_model.setRowCount(0);
+		table_ext_list.clear();
+	}
+
+	@Override
+	protected Resolution getSelectedTableContent() {
+		return getTableContent(table.getSelectedRow());
+	}
+
+	@Override
+	protected Resolution getTableContent(int rowIndex) {
+		return table_ext_list.get(rowIndex);
+	}
+}

--- a/src/main/java/core/packetproxy/model/Resolution.java
+++ b/src/main/java/core/packetproxy/model/Resolution.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.model;
+
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+import packetproxy.PrivateDNSClient;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@DatabaseTable(tableName = "resolutions")
+public class Resolution
+{
+    @DatabaseField(generatedId = true)
+    private int id;
+    @DatabaseField(uniqueCombo = true)
+    private String ip;
+    @DatabaseField(uniqueCombo = true)
+    private String hostname;
+    @DatabaseField
+    private boolean enabled;
+    @DatabaseField
+    private String comment;
+
+    public Resolution() {
+        // ORMLite needs a no-arg constructor
+    }
+    public Resolution(String ip, String hostname) {
+    	initialize(ip, hostname, false, "");
+    }
+    public Resolution(String ip, String hostname, boolean enabled, String comment) {
+    	initialize(ip, hostname, enabled, comment);
+    }
+    private void initialize(String ip, String hostname, boolean enabled, String comment) {
+        this.ip = ip;
+        this.hostname = hostname;
+        this.enabled = enabled;
+        this.comment = comment;
+    }
+
+    @Override
+	public String toString() {
+    	return String.format("%s to %s", ip, hostname);
+    }
+    public int getId() {
+    	return this.id;
+    }
+    public void setId(int id) {
+         this.id = id;
+    }
+    public String getIp() {
+        return this.ip;
+    }
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+    public String getHostName() {
+        return hostname;
+    }
+    public void setHostName(String hostname) {
+        this.hostname = hostname;
+    }
+    public void enableResolution() {
+        this.enabled = true;
+    }
+    public void disableResolution() {
+        this.enabled = false;
+    }
+    public boolean isEnabled() {
+    	return this.enabled;
+    }
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+    public String getComment() {
+    	return this.comment;
+    }
+    public void setComment(String comment) {
+    	this.comment = comment;
+    }
+}

--- a/src/main/java/core/packetproxy/model/Resolutions.java
+++ b/src/main/java/core/packetproxy/model/Resolutions.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.model;
+
+import com.j256.ormlite.dao.Dao;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Observable;
+import java.util.Observer;
+import packetproxy.model.DaoQueryCache;
+import packetproxy.model.Database.DatabaseMessage;
+
+public class Resolutions extends Observable implements Observer {
+
+	private static Resolutions instance;
+	
+	public static Resolutions getInstance() throws Exception {
+		if (instance == null) {
+			instance = new Resolutions();
+		}
+		return instance;
+	}
+	
+	private Database database;
+	private Dao<Resolution,Integer> dao;
+	private DaoQueryCache<Resolution> cache;
+	
+	private Resolutions() throws Exception {
+		database = Database.getInstance();
+		dao = database.createTable(Resolution.class, this);
+		cache = new DaoQueryCache();
+		if (dao.countOf() == 0) {
+			setResolutionsBySystem();
+		}
+	}
+	
+	public void setResolutionsBySystem() throws Exception {
+		List<String> fileLines = Files.readAllLines(Paths.get("/etc/hosts"));
+		fileLines.stream().forEach(line -> {
+			if (!(line.startsWith("#"))) {
+				try{
+					String ip = line.split("[\\s]+")[0];
+					String hostname = line.split("[\\s]+")[1];
+					create(new Resolution(ip, hostname));
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		});
+	}
+
+	public void create(Resolution resolution) throws Exception {
+		dao.createIfNotExists(resolution);
+		cache.clear();
+		notifyObservers();
+	}
+	public void delete(Resolution resolution) throws Exception {
+		dao.delete(resolution);
+		cache.clear();
+		notifyObservers();
+	}
+	public Resolution queryByString(String str) throws Exception {
+		List<Resolution> all = this.queryAll();
+		for (Resolution resolution : all) {
+			if (resolution.toString().equals(str)) {
+				return resolution;
+			}
+		}
+		return null;
+	}
+	public Resolution queryByHostName(String hostname) throws Exception {
+		List<Resolution> ret = cache.query("queryByHostName", hostname);
+		if (ret != null) { return ret.get(0); }
+
+		Resolution resolution = dao.queryBuilder().where().eq("ip", hostname).queryForFirst();
+
+		cache.set("queryByHostName", hostname, resolution);
+		return resolution;
+	}
+	public Resolution query(int id) throws Exception {
+		List<Resolution> ret = cache.query("query", id);
+		if (ret != null) { return ret.get(0); }
+
+		Resolution resolution = dao.queryForId(id);
+
+		cache.set("query", id, resolution);
+		return resolution;
+	}
+	public List<Resolution> queryAll() throws Exception {
+		List<Resolution> ret = cache.query("queryAll", 0);
+		if (ret != null) { return ret; }
+
+		ret = dao.queryBuilder().orderBy("ip", true).query();
+
+		cache.set("queryAll", 0, ret);
+		return ret;
+	}
+	public List<Resolution> queryEnabled() throws Exception {
+		List<Resolution> ret = cache.query("queryEnabled", 0);
+		if (ret != null) { return ret; }
+
+		ret = dao.queryBuilder().where().eq("enabled", true).query();
+
+		cache.set("queryEnabled", 0, ret);
+		return ret;
+	}
+	public void update(Resolution resolution) throws Exception {
+		dao.update(resolution);
+		cache.clear();
+		notifyObservers();
+	}
+	@Override
+	public void notifyObservers(Object arg) {
+		setChanged();
+		super.notifyObservers(arg);
+		clearChanged();
+	}
+	@Override
+	public void update(Observable o, Object arg) {
+		DatabaseMessage message = (DatabaseMessage)arg;
+		try {
+			switch (message) {
+			case PAUSE:
+				// TODO ロックを取る
+				break;
+			case RESUME:
+				// TODO ロックを解除
+				break;
+			case DISCONNECT_NOW:
+				break;
+			case RECONNECT:
+				database = Database.getInstance();
+				dao = database.createTable(Resolution.class, this);
+				cache.clear();
+				notifyObservers(arg);
+				break;
+			case RECREATE:
+				database = Database.getInstance();
+				dao = database.createTable(Resolution.class, this);
+				cache.clear();
+				break;
+			default:
+				break;
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
IPアドレスとHostnameを指定して、優先的な名前解決を行えるようにしました。

- Option>Hostname Resolutionsの項目を追加した
  - 初期は/etc/hostsの内容を読み込んで表示される
  - Addすることで任意の設定を追加可能
  - Overrideにチェックがついている場合は設定の通りに名前解決する

[ ] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
