### PR TITLE
Port TypeがFORWARDERの時などに再送が出来ない問題の修正

### DIFF
--- a/src/main/java/core/packetproxy/common/EndpointFactory.java
+++ b/src/main/java/core/packetproxy/common/EndpointFactory.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
+import java.util.Objects;
 
 public class EndpointFactory
 {
@@ -71,7 +72,7 @@ public class EndpointFactory
 	}
 	
 	public static Endpoint createFromOneShotPacket(OneShotPacket packet) throws Exception {
-		if (packet.getAlpn().equals("h3")) {
+		if (Objects.equals(packet.getAlpn(), "h3")) {
 			// HTTP3 on QUICの場合は特別対応
 			return new ServerConnection(ConnectionIdPair.generateRandom(), packet.getServerName(), packet.getServerPort());
 		} else if (packet.getUseSSL()) {


### PR DESCRIPTION
OptionsのListen Portsで選択するPort TypeがFORWARDERの時に、

- Historyのsend、send x 20を押しても反応がない
- Resenderのsend、send x 20を押しても反応がない

という問題がありました。

原因としては、Port TypeがFORWARDERの時に`packet.getAlpn()`がnullを返すため、修正箇所において、NullPointerExceptionが発生していました。`Objects.equals`を使って修正しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
