### PR TITLE
Private DNS Server の IPv6 対応

### DIFF
--- a/src/main/java/core/org/xbill/DNS/DNSSpoofingIPGetter.java
+++ b/src/main/java/core/org/xbill/DNS/DNSSpoofingIPGetter.java
@@ -16,4 +16,8 @@ public class DNSSpoofingIPGetter {
 		return gui.getSpoofingIP();
 	}
 
+		public String get6(){
+		return gui.getSpoofingIP6();
+	}
+
 }

--- a/src/main/java/core/org/xbill/DNS/jnamed.java
+++ b/src/main/java/core/org/xbill/DNS/jnamed.java
@@ -280,7 +280,12 @@ addAnswer(Message response, Name name, int type, int dclass,
 
 	try {
 		if (spoofIP != null) {
-			RRset rrset = new RRset(new ARecord(name, dclass, 0, InetAddress.getByName(spoofIP)));
+			RRset rrset;
+			if(type == 1){
+				rrset = new RRset(new ARecord(name, dclass, 0, InetAddress.getByName(spoofIP)));
+			} else {
+				rrset = new RRset(new AAAARecord(name, dclass, 0, InetAddress.getByName(spoofIP)));
+			}
 			addRRset(name, response, rrset, Section.ANSWER, flags);
 		}
 	} catch (Exception e) {

--- a/src/main/java/core/packetproxy/PrivateDNS.java
+++ b/src/main/java/core/packetproxy/PrivateDNS.java
@@ -20,6 +20,7 @@ import java.net.BindException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
@@ -28,7 +29,9 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.net.util.SubnetUtils;
 import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
@@ -57,36 +60,60 @@ public class PrivateDNS
 	
 	class SpoofAddrFactory {
 		private List<SubnetInfo> subnets = new ArrayList<SubnetInfo>();
+		private Map<Integer,Inet6Address> ifscopes = new HashMap<>();
 		private String defaultAddr = null;
+		private Inet6Address defaultAddr6 = null;
 
 		SpoofAddrFactory() throws Exception {
-			Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
-			for (NetworkInterface netint : Collections.list(nets)) {
-				for (InterfaceAddress intAddress : netint.getInterfaceAddresses()) {
-					InetAddress addr = intAddress.getAddress();
-					if (addr instanceof Inet4Address) {
-						short length = intAddress.getNetworkPrefixLength();
-						if(length<0)continue;
-						String cidr = String.format("%s/%d", addr.getHostAddress(),length);
-						SubnetUtils subnet = new SubnetUtils(cidr);
-						subnets.add(subnet.getInfo());
-						if (defaultAddr == null) {
-							defaultAddr = addr.getHostAddress();
-						} else if (defaultAddr.equals("127.0.0.1")) {
-							defaultAddr = addr.getHostAddress();
-						}
-					}
-				}
-			}
-		}
-		String getSpoofAddr(String addr) {
-			for (SubnetInfo subnet : subnets) {
-				if (subnet.isInRange(addr)) {
-					return subnet.getAddress();
-				}
-			}
-			return defaultAddr;
-		}
+            Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
+            for (NetworkInterface netint : Collections.list(nets)) {
+                for (InterfaceAddress intAddress : netint.getInterfaceAddresses()) {
+                    InetAddress addr = intAddress.getAddress();
+                    if (addr instanceof Inet4Address) {
+                        short length = intAddress.getNetworkPrefixLength();
+                        if(length<0)continue;
+                        String cidr = String.format("%s/%d", addr.getHostAddress(),length);
+                        SubnetUtils subnet = new SubnetUtils(cidr);
+                        subnets.add(subnet.getInfo());
+                        if (defaultAddr == null) {
+                            defaultAddr = addr.getHostAddress();
+                        } else if (defaultAddr.equals("127.0.0.1")) {
+                            defaultAddr = addr.getHostAddress();
+                        }
+                    } else {
+                        if( !addr.isMulticastAddress() && !addr.isLinkLocalAddress() && !addr.isSiteLocalAddress() ){
+                            ifscopes.put(((Inet6Address)addr).getScopeId(), (Inet6Address)addr);
+                            if (defaultAddr6 == null) {
+                                defaultAddr6 = (Inet6Address)addr;
+                            } else if (defaultAddr6.isLoopbackAddress()) {
+                                defaultAddr6 = (Inet6Address)addr;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Map<Integer,String> getSpoofAddr(InetAddress addr) {
+            Map<Integer,String> spoofAddrs = new HashMap<>();
+            if (addr instanceof Inet4Address) {
+                for (SubnetInfo subnet : subnets) {
+                    if (subnet.isInRange(addr.getHostAddress())) {
+                        spoofAddrs.put(4, subnet.getAddress());
+                    } else {
+                        spoofAddrs.put(4, defaultAddr);
+                    }
+                }
+                spoofAddrs.put(6, defaultAddr6.getHostAddress());
+            } else {
+                if (ifscopes.containsKey(((Inet6Address)addr).getScopeId())) {
+                    spoofAddrs.put(6, ifscopes.get(((Inet6Address)addr).getScopeId()).getHostAddress());
+                } else {
+                    spoofAddrs.put(6, defaultAddr6.getHostAddress());
+                }
+                spoofAddrs.put(4, defaultAddr);
+            }
+            return spoofAddrs;
+        }
 	}
 
 	public static PrivateDNS getInstance() throws Exception {
@@ -193,36 +220,69 @@ public class PrivateDNS
 					cAddr = recvPacket.getAddress();
 					cPort = recvPacket.getPort();
 
+					Map<Integer,String>  spoofingIpStrs = new HashMap<>();
 					String spoofingIpStr = "";
+					String spoofingIp6Str = "";
+
+					// if (cAddr instanceof Inet6Address) {
+					// 	util.packetProxyLog(String.format("[ScopeID] %s", ((Inet6Address)cAddr).getScopeId()));
+					// }
 					if (spoofingIp.isAuto()) {
-						String hostAddrStr = cAddr.getHostAddress();
-						if (hostAddrStr.equals("0:0:0:0:0:0:0:1")) {
-							hostAddrStr = "127.0.0.1";
-						}
-						spoofingIpStr = spoofAddrFactry.getSpoofAddr(hostAddrStr);
+						spoofingIpStrs = spoofAddrFactry.getSpoofAddr(cAddr);
+						spoofingIpStr = spoofingIpStrs.get(4);
+						spoofingIp6Str = spoofingIpStrs.get(6);;
 					} else {
 						spoofingIpStr = spoofingIp.get();
+						spoofingIp6Str = spoofingIp.get6();
 					}
+
+					// util.packetProxyLog(String.format("[hostAddrStr] %s", cAddr.getHostAddress()));
+					// util.packetProxyLog(String.format("[SpoofingIP] %s : %s", spoofingIpStr, spoofingIp6Str));
 
 					byte[] requestData = recvPacket.getData();
 
 					Message smsg = new Message(requestData);
 					byte[] smsgBA = smsg.toWire();
-
+					int queryRecType = smsg.getQuestion().getType();
 					String queryHostName = smsg.getQuestion().getName().toString(true);
-
+					String queryRecTypeName = Type.string(queryRecType);
+					InetAddress addr;
 					byte[] res = null;
+
 					try {
-						if (smsg.getQuestion().getType() != Type.A) {
+						if (queryRecType == Type.A ){
+							addr = PrivateDNSClient.getByName(queryHostName);
+							if (addr instanceof Inet6Address) {
+								throw new UnknownHostException();
+							}
+						} else if (queryRecType == Type.AAAA) {
+							addr = PrivateDNSClient.getByName6(queryHostName);
+							if (addr == null ) {
+								throw new UnknownHostException();
+							}
+						} else {
+							util.packetProxyLog(String.format("[DNS Query] Unsupport Query Type %s : '%s'", queryRecTypeName, queryHostName));
 							throw new UnsupportedOperationException();
 						}
 
-						util.packetProxyLog(String.format("[DNS Query] '%s'", queryHostName));
+						String ip = addr.getHostAddress();
 
-						String ip = PrivateDNSClient.getByName(queryHostName).getHostAddress();
+						util.packetProxyLog(String.format("[DNS Query] %s : '%s'", queryRecTypeName, queryHostName));
+						// util.packetProxyLog(String.format("[DNS Response Address] '%s'", ip));
+
 						if (isTargetHost(queryHostName)) {
-							ip = spoofingIpStr;
-							util.packetProxyLog("Replaced to " + spoofingIpStr);
+							if (queryRecType == Type.A ){
+							//ToDo GUIにIPv4有効チェックを追加し、無効のときはスキップするようにする。
+								ip = spoofingIpStr;
+                                util.packetProxyLog("Replaced to " + ip);
+							}
+						}
+						if (isTargetHost6(queryHostName)) {
+							if (queryRecType == Type.AAAA ){
+								//ToDo GUIにIPv6有効チェックを追加し、無効のときはスキップするようにする。
+								ip = spoofingIp6Str;
+                                util.packetProxyLog("Replaced to " + ip);
+							}
 						}
 						jnamed jn = new jnamed(ip);
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
@@ -261,6 +321,15 @@ public class PrivateDNS
 
 		private boolean isTargetHost(String hostName) throws Exception {
 			List<Server> server_list = servers.queryResolvedByDNS();
+			for (Server server : server_list) {
+				if (hostName.equals(server.getIp())) {
+					return true;
+				}
+			}
+			return false;
+		}
+		private boolean isTargetHost6(String hostName) throws Exception {
+			List<Server> server_list = servers.queryResolvedByDNS6();
 			for (Server server : server_list) {
 				if (hostName.equals(server.getIp())) {
 					return true;

--- a/src/main/java/core/packetproxy/PrivateDNS.java
+++ b/src/main/java/core/packetproxy/PrivateDNS.java
@@ -65,55 +65,55 @@ public class PrivateDNS
 		private Inet6Address defaultAddr6 = null;
 
 		SpoofAddrFactory() throws Exception {
-            Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
-            for (NetworkInterface netint : Collections.list(nets)) {
-                for (InterfaceAddress intAddress : netint.getInterfaceAddresses()) {
-                    InetAddress addr = intAddress.getAddress();
-                    if (addr instanceof Inet4Address) {
-                        short length = intAddress.getNetworkPrefixLength();
-                        if(length<0)continue;
-                        String cidr = String.format("%s/%d", addr.getHostAddress(),length);
-                        SubnetUtils subnet = new SubnetUtils(cidr);
-                        subnets.add(subnet.getInfo());
-                        if (defaultAddr == null) {
-                            defaultAddr = addr.getHostAddress();
-                        } else if (defaultAddr.equals("127.0.0.1")) {
-                            defaultAddr = addr.getHostAddress();
-                        }
-                    } else {
-                        if( !addr.isMulticastAddress() && !addr.isLinkLocalAddress() && !addr.isSiteLocalAddress() ){
-                            ifscopes.put(((Inet6Address)addr).getScopeId(), (Inet6Address)addr);
-                            if (defaultAddr6 == null) {
-                                defaultAddr6 = (Inet6Address)addr;
-                            } else if (defaultAddr6.isLoopbackAddress()) {
-                                defaultAddr6 = (Inet6Address)addr;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Map<Integer,String> getSpoofAddr(InetAddress addr) {
-            Map<Integer,String> spoofAddrs = new HashMap<>();
-            if (addr instanceof Inet4Address) {
-                for (SubnetInfo subnet : subnets) {
-                    if (subnet.isInRange(addr.getHostAddress())) {
-                        spoofAddrs.put(4, subnet.getAddress());
-                    } else {
-                        spoofAddrs.put(4, defaultAddr);
-                    }
-                }
-                spoofAddrs.put(6, defaultAddr6.getHostAddress());
-            } else {
-                if (ifscopes.containsKey(((Inet6Address)addr).getScopeId())) {
-                    spoofAddrs.put(6, ifscopes.get(((Inet6Address)addr).getScopeId()).getHostAddress());
-                } else {
-                    spoofAddrs.put(6, defaultAddr6.getHostAddress());
-                }
-                spoofAddrs.put(4, defaultAddr);
-            }
-            return spoofAddrs;
-        }
+	            Enumeration<NetworkInterface> nets = NetworkInterface.getNetworkInterfaces();
+	            for (NetworkInterface netint : Collections.list(nets)) {
+	                for (InterfaceAddress intAddress : netint.getInterfaceAddresses()) {
+	                    InetAddress addr = intAddress.getAddress();
+	                    if (addr instanceof Inet4Address) {
+	                        short length = intAddress.getNetworkPrefixLength();
+	                        if(length<0)continue;
+	                        String cidr = String.format("%s/%d", addr.getHostAddress(),length);
+	                        SubnetUtils subnet = new SubnetUtils(cidr);
+	                        subnets.add(subnet.getInfo());
+	                        if (defaultAddr == null) {
+	                            defaultAddr = addr.getHostAddress();
+	                        } else if (defaultAddr.equals("127.0.0.1")) {
+	                            defaultAddr = addr.getHostAddress();
+	                        }
+	                    } else {
+	                        if( !addr.isMulticastAddress() && !addr.isLinkLocalAddress() && !addr.isSiteLocalAddress() ){
+	                            ifscopes.put(((Inet6Address)addr).getScopeId(), (Inet6Address)addr);
+	                            if (defaultAddr6 == null) {
+	                                defaultAddr6 = (Inet6Address)addr;
+	                            } else if (defaultAddr6.isLoopbackAddress()) {
+	                                defaultAddr6 = (Inet6Address)addr;
+	                            }
+	                        }
+	                    }
+	                }
+	            }
+	        }
+	        Map<Integer,String> getSpoofAddr(InetAddress addr) {
+	            Map<Integer,String> spoofAddrs = new HashMap<>();
+	            if (addr instanceof Inet4Address) {
+	                for (SubnetInfo subnet : subnets) {
+	                    if (subnet.isInRange(addr.getHostAddress())) {
+	                        spoofAddrs.put(4, subnet.getAddress());
+	                    } else {
+	                        spoofAddrs.put(4, defaultAddr);
+	                    }
+	                }
+	                spoofAddrs.put(6, defaultAddr6.getHostAddress());
+	            } else {
+	                if (ifscopes.containsKey(((Inet6Address)addr).getScopeId())) {
+	                    spoofAddrs.put(6, ifscopes.get(((Inet6Address)addr).getScopeId()).getHostAddress());
+	                } else {
+	                    spoofAddrs.put(6, defaultAddr6.getHostAddress());
+	                }
+	                spoofAddrs.put(4, defaultAddr);
+	            }
+	            return spoofAddrs;
+	        }
 	}
 
 	public static PrivateDNS getInstance() throws Exception {

--- a/src/main/java/core/packetproxy/PrivateDNSClient.java
+++ b/src/main/java/core/packetproxy/PrivateDNSClient.java
@@ -16,8 +16,14 @@
 
 package packetproxy;
 
+import org.xbill.DNS.AAAARecord;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Type;
+import org.xbill.DNS.Record;
 import org.xbill.DNS.Address;
 import org.xbill.DNS.SystemResolverConfig;
+import org.xbill.DNS.TextParseException;
+
 import packetproxy.util.PacketProxyUtility;
 
 import java.net.InetAddress;
@@ -111,4 +117,20 @@ public class PrivateDNSClient {
         return dnsLooping(serverName) ? Address.getAllByName(serverName) : InetAddress.getAllByName(serverName);
     }
 
+    public static InetAddress getByName6(String host) {
+        InetAddress hostIP;
+        try {
+            Lookup lookup = new Lookup(host, Type.AAAA);
+            // lookup.setResolver(resolver);
+            Record[] records = lookup.run();
+            if (records == null) {
+                return null;
+            }
+            hostIP = ((AAAARecord) records[0]).getAddress();
+        } catch (TextParseException ex) {
+            util.packetProxyLog(String.format("'%s'", ex.getMessage()));
+            throw new IllegalStateException(ex);
+        }
+        return hostIP;
+    }
 }

--- a/src/main/java/core/packetproxy/gui/GUIOptionServers.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionServers.java
@@ -44,8 +44,8 @@ public class GUIOptionServers extends GUIOptionComponentBase<Server>
 		servers = Servers.getInstance();
 		servers.addObserver(this);
 		server_list = new ArrayList<Server>();
-		String[] menu = { "Host", "Port", "Use SSL", "Encode Module", "Spoof DNS", "HttpProxy", "Comment" };
-		int[] menuWidth = { 200, 80, 50, 160, 60, 60, 100 };
+		String[] menu = { "Host", "Port", "Use SSL", "Encode Module", "Spoof DNS(A)", "Spoof DNS(AAAA)", "HttpProxy", "Comment" };
+		int[] menuWidth = { 200, 80, 50, 160, 60, 60, 60, 100 };
 		MouseAdapter tableAction = new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
@@ -59,6 +59,16 @@ public class GUIOptionServers extends GUIOptionComponentBase<Server>
 							server.disableResolved();
 						} else {
 							server.enableResolved();
+						}
+						servers.update(server);
+					}
+					if (columnIndex == 5) { /* Spoof DNS area */
+						boolean enable_checkbox = (Boolean)table.getValueAt(rowIndex, 5);
+						Server server = getSelectedTableContent();
+						if (enable_checkbox == true) {
+							server.disableResolved6();
+						} else {
+							server.enableResolved6();
 						}
 						servers.update(server);
 					}
@@ -117,6 +127,7 @@ public class GUIOptionServers extends GUIOptionComponentBase<Server>
 				server.getUseSSL(),
 				server.getEncoder(),
 				server.isResolved(),
+				server.isResolved6(),
 				server.isHttpProxy(),
 				server.getComment()});
 	}

--- a/src/main/java/core/packetproxy/model/Server.java
+++ b/src/main/java/core/packetproxy/model/Server.java
@@ -42,6 +42,8 @@ public class Server
     @DatabaseField
     private boolean resolved_by_dns;
     @DatabaseField
+    private boolean resolved_by_dns6;
+    @DatabaseField
     private boolean http_proxy;
     @DatabaseField
     private String comment;
@@ -52,17 +54,18 @@ public class Server
         // ORMLite needs a no-arg constructor 
     }
     public Server(String ip, int port, String encoder) {
-    	initialize(ip, port, false, encoder, false, false, "");
+        initialize(ip, port, false, encoder, false, false, false, "");
     }
-    public Server(String ip, int port, boolean use_ssl, String encoder, boolean resolved_by_dns, boolean http_proxy, String comment) {
-    	initialize(ip, port, use_ssl, encoder, resolved_by_dns, http_proxy, comment);
+    public Server(String ip, int port, boolean use_ssl, String encoder, boolean resolved_by_dns, boolean resolved_by_dns6, boolean http_proxy, String comment) {
+        initialize(ip, port, use_ssl, encoder, resolved_by_dns, resolved_by_dns6, http_proxy, comment);
     }
-    private void initialize(String ip, int port, boolean use_ssl, String encoder, boolean resolved_by_dns, boolean http_proxy, String comment) {
+    private void initialize(String ip, int port, boolean use_ssl, String encoder, boolean resolved_by_dns, boolean resolved_by_dns6, boolean http_proxy, String comment) {
         this.ip = ip;
         this.port = port;
         this.use_ssl = use_ssl;
         this.encoder = encoder;
         this.resolved_by_dns = resolved_by_dns;
+        this.resolved_by_dns6 = resolved_by_dns6;
         this.http_proxy = http_proxy;
         this.comment = comment;
         this.specifiedByHostName = isHostName(ip);
@@ -129,6 +132,18 @@ public class Server
     }
     public void setResolved(boolean resolved_by_dns) {
         this.resolved_by_dns = resolved_by_dns;
+    }
+    public void enableResolved6() {
+        this.resolved_by_dns6 = true;
+    }
+    public void disableResolved6() {
+        this.resolved_by_dns6 = false;
+    }
+    public boolean isResolved6() {
+        return this.resolved_by_dns6;
+    }
+    public void setResolved6(boolean resolved_by_dns6) {
+        this.resolved_by_dns6 = resolved_by_dns6;
     }
     public String getComment() {
     	return this.comment;

--- a/src/main/java/core/packetproxy/model/Servers.java
+++ b/src/main/java/core/packetproxy/model/Servers.java
@@ -154,6 +154,15 @@ public class Servers extends Observable implements Observer {
 		cache.set("queryResolvedByDNS", 0, ret);
 		return ret;
 	}
+	public List<Server> queryResolvedByDNS6() throws Exception {
+		List<Server> ret = cache.query("queryResolvedByDNS6", 0);
+		if (ret != null) { return ret; }
+
+		ret = dao.queryBuilder().where().eq("resolved_by_dns6", true).query();
+
+		cache.set("queryResolvedByDNS6", 0, ret);
+		return ret;
+	}
 	public void update(Server server) throws Exception {
 		dao.update(server);
 		cache.clear();


### PR DESCRIPTION
Private DNS Server でAAAAレコードを扱えるようにしました。
合わせてPrivate DNS Server によるAAAAレコードのSpoofingも行えるようにしています。

 - GUIの変更箇所
   - Options>Servers の「DNS偽装」項目に Aレコード、AAAAレコード の偽装を個別に選べるチェックボックを追加
   - Options>Private DNS Server の「書き換え先IP」にIPv6用のテキストボックを追加

[x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
