### PR TITLE
Protobuf Encoderに外部ツールから利用できる機能を追加

### DIFF
--- a/src/main/java/core/packetproxy/PrivateDNS.java
+++ b/src/main/java/core/packetproxy/PrivateDNS.java
@@ -267,13 +267,13 @@ public class PrivateDNS
 							soc.send(sendPacket);
 							continue;
 						} else {
-							util.packetProxyLog(String.format("[DNS Query] Unsupported Query Type %s : '%s'", queryRecTypeName, queryHostName));
+							util.packetProxyLog(String.format("[DNS Query] Unsupported Query Type: '%s' [%s]", queryHostName, queryRecTypeName));
 							throw new UnsupportedOperationException();
 						}
 
 						String ip = addr.getHostAddress();
 
-						util.packetProxyLog(String.format("[DNS Query] %s : '%s'", queryRecTypeName, queryHostName));
+						util.packetProxyLog(String.format("[DNS Query] '%s' [%s]", queryHostName, queryRecTypeName));
 						// util.packetProxyLog(String.format("[DNS Response Address] '%s'", ip));
 
 						if (isTargetHost(queryHostName)) {
@@ -294,7 +294,7 @@ public class PrivateDNS
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 
 					} catch(UnknownHostException e) {
-						util.packetProxyLogErr(String.format("[DNS Query] Unknown Host: '%s'", queryHostName));
+						util.packetProxyLogErr(String.format("[DNS Query] Unknown Host: '%s' [%s]", queryHostName, queryRecTypeName));
 						jnamed jn = new jnamed();
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 
@@ -304,7 +304,7 @@ public class PrivateDNS
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 
 					} catch(Exception e) {
-						util.packetProxyLogErr(String.format("[DNS Query] Unknown Error: '%s'", queryHostName));
+						util.packetProxyLogErr(String.format("[DNS Query] Unknown Error: '%s' [%s]", queryHostName, queryRecTypeName));
 						jnamed jn = new jnamed();
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 

--- a/src/main/java/core/packetproxy/encode/EncodeProtobuf.java
+++ b/src/main/java/core/packetproxy/encode/EncodeProtobuf.java
@@ -45,21 +45,40 @@ public class EncodeProtobuf extends EncodeHTTPBase
 
 	@Override
 	protected Http decodeClientRequestHttp(Http inputHttp) throws Exception {
-		return decodeProtobuf3(inputHttp);
+		if (inputHttp.getFirstHeader("X-PacketProxy").contains("true")) {
+            encode_mode = 1;
+			return inputHttp;
+        }
+		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+            return decodeProtobuf3(inputHttp);
+        }
+		return inputHttp;
 	}
 
 	@Override
 	protected Http encodeClientRequestHttp(Http inputHttp) throws Exception {
-		return encodeProtobuf3(inputHttp);
+		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+            return encodeProtobuf3(inputHttp);
+        }
+		return inputHttp;
 	}
 
 	@Override
 	protected Http decodeServerResponseHttp(Http inputHttp) throws Exception {
-		return decodeProtobuf3(inputHttp);
+		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+            return decodeProtobuf3(inputHttp);
+        }
+		return inputHttp;
 	}
 
 	@Override
 	protected Http encodeServerResponseHttp(Http inputHttp) throws Exception {
-		return encodeProtobuf3(inputHttp);
+		if (encode_mode == 1) {
+			return inputHttp;
+		}
+		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+            return encodeProtobuf3(inputHttp);
+        }
+		return inputHttp;
 	}
 }

--- a/src/main/java/core/packetproxy/encode/Encoder.java
+++ b/src/main/java/core/packetproxy/encode/Encoder.java
@@ -33,6 +33,7 @@ public abstract class Encoder
 	private PipedOutputStream serverOutputForFlowControl;
 	private PipedInputStream serverInputForFlowControl;
 	private String ALPN;
+	public int encode_mode;
 	
 	public Encoder(String alpn) {
 		this.ALPN = alpn;


### PR DESCRIPTION
「X-PacketProxy: true」ヘッダを付与することで外部ツール(SQLMAP等)からの平文でのリクエストをProtobuf EncoderでEncode/Decodeする機能を追加しました。

[x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
