### PR TITLE
PR(#146)の実装場所を変更

### DIFF
--- a/src/main/java/core/packetproxy/encode/EncodeHTTPBase.java
+++ b/src/main/java/core/packetproxy/encode/EncodeHTTPBase.java
@@ -156,7 +156,12 @@ public abstract class EncodeHTTPBase extends Encoder
 			input_data = http3.decodeClientRequest(input_data);
 		}
 		Http http = Http.create(input_data);
-		Http decodedHttp = decodeClientRequestHttp(http);
+		Http decodedHttp = http;
+		if (http.getFirstHeader("X-PacketProxy-Skip-ClientSideEncode").contains("true")) {
+			encode_mode = 1;
+		} else {
+			decodedHttp = decodeClientRequestHttp(http);
+		}
 		return decodedHttp.toByteArray();
 	}
 
@@ -199,7 +204,10 @@ public abstract class EncodeHTTPBase extends Encoder
 		} else {
 			http = Http.create(input_data);
 		}
-		Http encodedHttp = encodeServerResponseHttp(http);
+		Http encodedHttp = http;
+		if (encode_mode == 0) {
+			encodedHttp = encodeServerResponseHttp(http);
+		}
 		byte[] encodedData = encodedHttp.toByteArray();
 		if (this.httpVersion == HTTPVersion.HTTP2) { 
 			encodedData = http2.encodeServerResponse(encodedData);

--- a/src/main/java/core/packetproxy/encode/EncodeProtobuf.java
+++ b/src/main/java/core/packetproxy/encode/EncodeProtobuf.java
@@ -45,10 +45,6 @@ public class EncodeProtobuf extends EncodeHTTPBase
 
 	@Override
 	protected Http decodeClientRequestHttp(Http inputHttp) throws Exception {
-		if (inputHttp.getFirstHeader("X-PacketProxy").contains("true")) {
-            encode_mode = 1;
-			return inputHttp;
-        }
 		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
             return decodeProtobuf3(inputHttp);
         }
@@ -73,9 +69,6 @@ public class EncodeProtobuf extends EncodeHTTPBase
 
 	@Override
 	protected Http encodeServerResponseHttp(Http inputHttp) throws Exception {
-		if (encode_mode == 1) {
-			return inputHttp;
-		}
 		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
             return encodeProtobuf3(inputHttp);
         }


### PR DESCRIPTION
#146 で実装した機能をより広い範囲で利用できるようにEncodeHTTPBaseに移動。
また、付与するヘッダの名前を機能がわかりやすいように「X-PacketProxy-Skip-ClientSideEncode」に変更。

[x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
