### PR TITLE
Protocol buffer sometimes used with octet-stream

### DIFF
--- a/src/main/java/core/packetproxy/encode/EncodeProtobuf.java
+++ b/src/main/java/core/packetproxy/encode/EncodeProtobuf.java
@@ -45,7 +45,8 @@ public class EncodeProtobuf extends EncodeHTTPBase
 
 	@Override
 	protected Http decodeClientRequestHttp(Http inputHttp) throws Exception {
-		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+		var contentType = inputHttp.getFirstHeader("Content-Type");
+		if (contentType.contains("protobuf") || contentType.startsWith("application/octet-stream")) {
             return decodeProtobuf3(inputHttp);
         }
 		return inputHttp;
@@ -53,7 +54,8 @@ public class EncodeProtobuf extends EncodeHTTPBase
 
 	@Override
 	protected Http encodeClientRequestHttp(Http inputHttp) throws Exception {
-		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+		var contentType = inputHttp.getFirstHeader("Content-Type");
+		if (contentType.contains("protobuf") || contentType.startsWith("application/octet-stream")) {
             return encodeProtobuf3(inputHttp);
         }
 		return inputHttp;
@@ -61,7 +63,8 @@ public class EncodeProtobuf extends EncodeHTTPBase
 
 	@Override
 	protected Http decodeServerResponseHttp(Http inputHttp) throws Exception {
-		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+		var contentType = inputHttp.getFirstHeader("Content-Type");
+		if (contentType.contains("protobuf") || contentType.startsWith("application/octet-stream")) {
             return decodeProtobuf3(inputHttp);
         }
 		return inputHttp;
@@ -69,7 +72,8 @@ public class EncodeProtobuf extends EncodeHTTPBase
 
 	@Override
 	protected Http encodeServerResponseHttp(Http inputHttp) throws Exception {
-		if (inputHttp.getFirstHeader("Content-Type").contains("protobuf")) {
+		var contentType = inputHttp.getFirstHeader("Content-Type");
+		if (contentType.contains("protobuf") || contentType.startsWith("application/octet-stream")) {
             return encodeProtobuf3(inputHttp);
         }
 		return inputHttp;


### PR DESCRIPTION
Protocol bufferでシリアライズしたデータを送信する際には、`application/x-protobuf`と`application/vnd.google.protobuf`以外に`application/octet-stream`を使用するケースもあります。

そのケースに対応するためのプルリクエストです。
`application/octet-stream`で送信、受信したデータをデシリアライズ/シリアライズするように変更しています。

[x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
