### PR TITLE
Fix markdown checkbox

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 Your content here
 
 
-[ ] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
+- [ ] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).


### PR DESCRIPTION
`.github/pull_request_template.md`のMarkdownのチェックボックスが壊れていて、Previewに上手く表示できていなかったので直しました。

Before:
<img width="451" alt="スクリーンショット 2024-03-23 5 12 59" src="https://github.com/DeNA/PacketProxy/assets/1628214/7028b42d-202e-4ed3-b181-ed1cfbac93b4">

After:
<img width="456" alt="スクリーンショット 2024-03-23 5 12 18" src="https://github.com/DeNA/PacketProxy/assets/1628214/c9657357-3a3e-4ba5-a92e-49127c3a8e29">




- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
