### PR TITLE
Fix java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String in Protobuf3.java

### DIFF
--- a/src/main/java/core/packetproxy/common/Protobuf3.java
+++ b/src/main/java/core/packetproxy/common/Protobuf3.java
@@ -314,7 +314,7 @@ public class Protobuf3
 			}
 			case "String": {
 				new Key(fieldNumber, Key.Type.LengthDelimited).writeTo(output);
-				String str = (String)messages.get(key); 
+				String str = messages.get(key).toString();
 				writeVar(str.getBytes().length, output);
 				output.write(str.getBytes());
 				break;


### PR DESCRIPTION
Protobuf3.javaの中で、Protocol Buffersへのシリアライズ時にIntegerからStringへのキャストに失敗し、`java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String`が出る箇所があったので直しました。

参考: [Why cannot cast Integer to String in java? - Stack Overflow](https://stackoverflow.com/questions/8973381/why-cannot-cast-integer-to-string-in-java)


- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
