### PR TITLE
Fix getCookie parsing on encode module

### DIFF
--- a/src/main/java/core/packetproxy/http/Http.java
+++ b/src/main/java/core/packetproxy/http/Http.java
@@ -616,7 +616,7 @@ public class Http
 		Map<String, String> cookieMap;
 		cookieMap = cookies
 			.stream()
-			.flatMap(v -> Arrays.stream(v.split(";")))
+			.flatMap(v -> Arrays.stream(v.split(";\\s*")))
 			.map(kv -> kv.split("="))
 			.collect(Collectors.toMap(
 						kv -> URLDecoder.decode(kv[0]),


### PR DESCRIPTION
EncodeHTTPBaseクラス等から参照されている HttpクラスのgetCookieメソッドにおいてCookieの2つ目以降のkeyのパースに失敗する問題を修正しました．


- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
