### PR TITLE
PrivateDNSサーバにバインドするインターフェイスを指定できるように変更。(0.0.0.0以外をバインドする場合はroot権限が必要)

### DIFF
--- a/src/main/java/core/org/xbill/DNS/DNSSpoofingIPGetter.java
+++ b/src/main/java/core/org/xbill/DNS/DNSSpoofingIPGetter.java
@@ -16,8 +16,11 @@ public class DNSSpoofingIPGetter {
 		return gui.getSpoofingIP();
 	}
 
-		public String get6(){
+	public String get6(){
 		return gui.getSpoofingIP6();
 	}
 
+	public String getInt(){
+		return gui.getBindInterface();
+	}
 }

--- a/src/main/java/core/packetproxy/PrivateDNS.java
+++ b/src/main/java/core/packetproxy/PrivateDNS.java
@@ -178,7 +178,7 @@ public class PrivateDNS
 		public PrivateDNSImp(DNSSpoofingIPGetter dnsSpoofingIPGetter) throws Exception {
 			try {
 				this.spoofingIp = dnsSpoofingIPGetter;
-				soc = new DatagramSocket(PORT);
+				soc = new DatagramSocket(PORT, InetAddress.getByName(spoofingIp.getInt()));
 				recvPacket = new DatagramPacket(buf, BUFSIZE);
 				sendPacket = null;
 			} catch (BindException e) {


### PR DESCRIPTION
PrivateDNSサーバ起動時のBinding Interfaceを指定できるようにしました。
※ 0.0.0.0以外をBindする場合はRoot権限が必要になります。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
