### PR TITLE
Protobuf3で通信を改ざんした際に意図しない挙動になることがあったのを修正

### DIFF
--- a/src/main/java/core/packetproxy/common/Protobuf3.java
+++ b/src/main/java/core/packetproxy/common/Protobuf3.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -207,6 +208,7 @@ public class Protobuf3
 	
 	public static byte[] encode(String input) throws Exception {
 		ObjectMapper mapper = new ObjectMapper();
+		mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
 		HashMap<String,Object> messages = mapper.readValue(input, new TypeReference<HashMap<String,Object>>(){});
 		return encodeData(messages);
 	}

--- a/src/main/java/core/packetproxy/common/Protobuf3.java
+++ b/src/main/java/core/packetproxy/common/Protobuf3.java
@@ -290,13 +290,13 @@ public class Protobuf3
 
 	public static byte[] encodeData(Map<String,Object> messages) throws Exception {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
-		String[] orderedKeys = new String[messages.keySet().size()];
+		TreeMap<String, String> orderedKeys = new TreeMap<String, String>();
 		messages.keySet().stream().forEach(key -> {
 			String[] keyval = key.split(":");
-			int ordinary    = Integer.parseInt(keyval[1], 16);
-			orderedKeys[ordinary] = key;
+			String index = String.format("%s-%s", keyval[1], key);
+			orderedKeys.put(index, key);
 		});
-		for (String key : orderedKeys) {
+		for (String key : orderedKeys.values()) {
 			String[] keyval = key.split(":");
 			long fieldNumber = Long.parseLong(keyval[0], 16);
 			String type      = keyval[2];


### PR DESCRIPTION
以下の2点を修正
- 重複したキーがある場合はエラーとするようにした
- 順序用のindexが連番になってないとエラーになる問題を修正

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
