### PR TITLE
パケットの色をSQLiteに保存するように修正

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIHistory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistory.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.concurrent.ExecutorService;
@@ -133,6 +134,10 @@ public class GUIHistory implements Observer
 	private boolean dialogOnce = false;
 	private GUIHistoryAutoScroll autoScroll;
 	private JPopupMenu menu;
+
+	private Color packetColorGreen = new Color(0x7f, 0xff, 0xd4);
+	private Color packetColorBrown = new Color(0xd2, 0x69, 0x1e);
+	private Color packetColorYellow = new Color(0xff, 0xd7, 0x00);
 
 	private GUIHistory(boolean restore) throws Exception {
 		packets = Packets.getInstance(restore);
@@ -261,7 +266,7 @@ public class GUIHistory implements Observer
 				}
 			}
 		});
-		
+
 		JPanel filter_panel = new JPanel();
 		filter_panel.setLayout(new BoxLayout(filter_panel, BoxLayout.X_AXIS));
 		filter_panel.add(gui_filter);
@@ -530,14 +535,15 @@ public class GUIHistory implements Observer
 		JMenuItem addColorG = createMenuItem ("add color (green)", -1, null, new ActionListener() {
 			public void actionPerformed(ActionEvent actionEvent) {
 				try {
-					Color color = new Color(0x7f, 0xff, 0xd4);
 					int[] selected_rows = table.getSelectedRows();
 					for (int i = 0; i < selected_rows.length; i++)
 					{
 						Integer id = (Integer) table.getValueAt(selected_rows[i], 0);
-						colorManager.add(id, color);
+						colorManager.add(id, packetColorGreen);
+						Packet packet = Packets.getInstance().query(id);
+						packet.setColor("green");
+						Packets.getInstance().update(packet);
 					}
-					
 				} catch (Exception e) {
 					e.printStackTrace();
 				}
@@ -547,12 +553,14 @@ public class GUIHistory implements Observer
 		JMenuItem addColorB = createMenuItem ("add color (brown)", -1, null, new ActionListener() {
 			public void actionPerformed(ActionEvent actionEvent) {
 				try {
-					Color color = new Color(0xd2, 0x69, 0x1e);
 					int[] selected_rows = table.getSelectedRows();
 					for (int i = 0; i < selected_rows.length; i++)
 					{
 						Integer id = (Integer) table.getValueAt(selected_rows[i], 0);
-						colorManager.add(id, color);
+						colorManager.add(id, packetColorBrown);
+						Packet packet = Packets.getInstance().query(id);
+						packet.setColor("brown");
+						Packets.getInstance().update(packet);
 					}
 				} catch (Exception e) {
 					e.printStackTrace();
@@ -563,12 +571,14 @@ public class GUIHistory implements Observer
 		JMenuItem addColorY = createMenuItem ("add color (yellow)", -1, null, new ActionListener() {
 			public void actionPerformed(ActionEvent actionEvent) {
 				try {
-					Color color = new Color(0xff, 0xd7, 0x00);
 					int[] selected_rows = table.getSelectedRows();
 					for (int i = 0; i < selected_rows.length; i++)
 					{
 						Integer id = (Integer) table.getValueAt(selected_rows[i], 0);
-						colorManager.add(id, color);
+						colorManager.add(id, packetColorYellow);
+						Packet packet = Packets.getInstance().query(id);
+						packet.setColor("yellow");
+						Packets.getInstance().update(packet);
 					}
 				} catch (Exception e) {
 					e.printStackTrace();
@@ -593,7 +603,7 @@ public class GUIHistory implements Observer
 
 		JMenuItem delete_selected_items = createMenuItem ("delete selected items", -1, null, new ActionListener() {
 			public void actionPerformed(ActionEvent actionEvent) {
-				try {		
+				try {
 					int[] selected_rows = table.getSelectedRows();
 					for (int i = 0; i < selected_rows.length; i++)
 					{
@@ -964,13 +974,24 @@ TODO: support --data-binary
 	}
 
 	public void updateAllAsync() throws Exception {
-		List<Packet> packetList = packets.queryAllIds();
+		List<Packet> packetList = packets.queryAllIdsAndColors();
 		tableModel.setRowCount(0);
 		for(Packet packet : packetList) {
+			int id = packet.getId();
+			String color = packet.getColor();
+
 			tableModel.addRow(new Object[] {
 				packet.getId(),"Loading...","Loading...",0,"Loading...","","Loading...","","00:00:00 1900/01/01 Z",false,false,"","","",(long)-1
 			});
-			id_row.put(packet.getId(), tableModel.getRowCount() - 1);
+			id_row.put(id, tableModel.getRowCount() - 1);
+
+			if (Objects.equals(color, "green")) {
+				colorManager.add(id, packetColorGreen);
+			} else if (Objects.equals(color, "brown")) {
+				colorManager.add(id, packetColorBrown);
+			} else if (Objects.equals(color, "yellow")) {
+				colorManager.add(id, packetColorYellow);
+			}
 		}
 		update_packet_ids.clear();
 

--- a/src/main/java/core/packetproxy/gui/GUIHistory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistory.java
@@ -976,6 +976,7 @@ TODO: support --data-binary
 	public void updateAllAsync() throws Exception {
 		List<Packet> packetList = packets.queryAllIdsAndColors();
 		tableModel.setRowCount(0);
+		colorManager.clear();
 		for(Packet packet : packetList) {
 			int id = packet.getId();
 			String color = packet.getColor();

--- a/src/main/java/core/packetproxy/gui/TableCustomColorManager.java
+++ b/src/main/java/core/packetproxy/gui/TableCustomColorManager.java
@@ -19,8 +19,6 @@ import java.awt.Color;
 import java.util.HashMap;
 import java.util.Map;
 
-import packetproxy.util.PacketProxyUtility;
-
 public class TableCustomColorManager {
 
 	class LineColor {
@@ -44,77 +42,36 @@ public class TableCustomColorManager {
 	}
 
 	private Map<Integer,LineColor> coloredLines;
-	private Map<Integer,LineColor> clearedLines;
 
 	public TableCustomColorManager() {
 		this.coloredLines = new HashMap<Integer, LineColor>();
-		this.clearedLines = new HashMap<Integer, LineColor>();
 	}
 
 	public void add(int packetId, Color color) {
 		coloredLines.put(packetId, new LineColor(packetId, color));
-		clearedLines.remove(packetId);
 	}
 
 	public void clear(int packetId) {
-		LineColor lc = coloredLines.get(packetId);
-		clearedLines.put(packetId, lc);
 		coloredLines.remove(packetId);
 	}
 
 	public void clear() {
-		coloredLines.forEach((key, value) -> {
-			clearedLines.putIfAbsent(key, value);
-		});
 		coloredLines.clear();
 	}
 
 	public boolean contains(int packetId) {
-		return (coloredLines.containsKey(packetId) || clearedLines.containsKey(packetId)) ? true : false;
+		return coloredLines.containsKey(packetId) ? true : false;
 	}
 
 	public Color getColor(int packetId) throws Exception {
 		if (coloredLines.containsKey(packetId)) {
 			return coloredLines.get(packetId).getColor();
-		} else if (clearedLines.containsKey(packetId)) {
-			return Color.WHITE;
 		}
 		throw new Exception("line color is not registered.");
 	}
 
 	@Override
 	public String toString() {
-		return "coloredLines: " + coloredLines.toString() + " clearedLines: " + clearedLines.toString();
+		return "coloredLines: " + coloredLines.toString();
 	}
-
-	/*
-	public static void main(String[] args) {
-		PacketProxyUtility util = PacketProxyUtility.getInstance();
-		try {
-			TableCustomColorManager manager = new TableCustomColorManager();
-			manager.add(1, Color.BLACK);
-			manager.add(2, Color.BLUE);
-			util.packetProxyLog(manager.toString());
-			util.packetProxyLog(manager.getColor(1).toString());
-			util.packetProxyLog(manager.getColor(2).toString());
-			manager.clear();
-			util.packetProxyLog(manager.toString());
-			util.packetProxyLog(manager.getColor(1).toString());
-			util.packetProxyLog(manager.getColor(2).toString());
-			util.packetProxyLog(manager.getColor(1).toString());
-			util.packetProxyLog(manager.getColor(2).toString());
-			manager.clear();
-			util.packetProxyLog(manager.toString());
-			util.packetProxyLog(manager.getColor(1).toString());
-			util.packetProxyLog(manager.getColor(2).toString());
-			manager.add(1, Color.BLACK);
-			util.packetProxyLog(manager.toString());
-			util.packetProxyLog(manager.getColor(1).toString());
-			util.packetProxyLog(manager.getColor(2).toString());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-	*/
-
 }

--- a/src/main/java/core/packetproxy/model/Packet.java
+++ b/src/main/java/core/packetproxy/model/Packet.java
@@ -71,9 +71,11 @@ public class Packet implements PacketInfo
 	private int conn;
 	@DatabaseField
 	private long group;
+	@DatabaseField
+	private String color;
 
 	public Packet() {
-		// ORMLite needs a no-arg constructor 
+		// ORMLite needs a no-arg constructor
 	}
 	public Packet(int listen_port, InetSocketAddress client_addr, InetSocketAddress server_addr, String server_name, boolean use_ssl, String encoder, String alpn, Direction dir, int conn, long group) {
 		initialize(listen_port,
@@ -244,6 +246,12 @@ public class Packet implements PacketInfo
 	}
 	public void setGroup(long group) {
 		this.group = group;
+	}
+	public String getColor() {
+		return this.color;
+	}
+	public void setColor(String color) {
+		this.color = color;
 	}
 	public String getSummarizedRequest() throws Exception {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, null);

--- a/src/main/java/core/packetproxy/model/Packets.java
+++ b/src/main/java/core/packetproxy/model/Packets.java
@@ -188,6 +188,11 @@ public class Packets extends Observable implements Observer {
 			case RECONNECT:
 				database = Database.getInstance();
 				dao = database.createTable(Packet.class, this);
+				// ファイル読み込み時にpacketsテーブルの中にcolorカラムがなかったら追加する
+				String result = dao.queryRaw("SELECT sql FROM sqlite_master WHERE name='packets'").getFirstResult()[0];
+				if (!result.contains("`color` VARCHAR")) {
+					dao.executeRaw("ALTER TABLE `packets` ADD COLUMN color VARCHAR");
+				}
 				notifyObservers(arg);
 				break;
 			case RECREATE:

--- a/src/main/java/core/packetproxy/model/Packets.java
+++ b/src/main/java/core/packetproxy/model/Packets.java
@@ -28,7 +28,7 @@ import packetproxy.util.PacketProxyUtility;
 
 public class Packets extends Observable implements Observer {
 	private static Packets instance;
-	
+
 	public static Packets getInstance(boolean restore) throws Exception {
 		if (instance == null) {
 			instance = new Packets(restore);
@@ -43,7 +43,7 @@ public class Packets extends Observable implements Observer {
 		}
 		return instance;
 	}
-	
+
 	private PacketProxyUtility util;
 	private Database database;
 	private Dao<Packet,Integer> dao;
@@ -120,9 +120,9 @@ public class Packets extends Observable implements Observer {
 	public Packet query(int id) throws Exception {
 		return dao.queryForId(id);
 	}
-	
-	public List<Packet> queryAllIds() throws Exception {
-		return dao.queryBuilder().selectColumns("id").orderBy("id", true).query();
+
+	public List<Packet> queryAllIdsAndColors() throws Exception {
+		return dao.queryBuilder().selectColumns("id", "color").orderBy("id", true).query();
 	}
 
 	public List<Packet> queryRange(long offset, long limit) throws Exception {
@@ -204,7 +204,7 @@ public class Packets extends Observable implements Observer {
 	private boolean isLatestVersion() throws Exception {
 		String result = dao.queryRaw("SELECT sql FROM sqlite_master WHERE name='packets'").getFirstResult()[0];
 		//System.out.println(result);
-		return result.equals("CREATE TABLE `packets` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `direction` VARCHAR , `decoded_data` BLOB , `modified_data` BLOB , `sent_data` BLOB , `received_data` BLOB , `listen_port` INTEGER , `client_ip` VARCHAR , `client_port` INTEGER , `server_ip` VARCHAR , `server_name` VARCHAR , `server_port` INTEGER , `use_ssl` BOOLEAN , `content_type` VARCHAR , `encoder_name` VARCHAR , `alpn` VARCHAR , `modified` BOOLEAN , `resend` BOOLEAN , `date` BIGINT , `conn` INTEGER , `group` BIGINT )");
+		return result.equals("CREATE TABLE `packets` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `direction` VARCHAR , `decoded_data` BLOB , `modified_data` BLOB , `sent_data` BLOB , `received_data` BLOB , `listen_port` INTEGER , `client_ip` VARCHAR , `client_port` INTEGER , `server_ip` VARCHAR , `server_name` VARCHAR , `server_port` INTEGER , `use_ssl` BOOLEAN , `content_type` VARCHAR , `encoder_name` VARCHAR , `alpn` VARCHAR , `modified` BOOLEAN , `resend` BOOLEAN , `date` BIGINT , `conn` INTEGER , `group` BIGINT , `color` VARCHAR )");
 	}
 	private void RecreateTable() throws Exception {
 		int option = JOptionPane.showConfirmDialog(null,


### PR DESCRIPTION
パケットに色をつけることが出来ますが、メモリ上に保持されているだけで、再起動時には消えてしまっていました。
そのため、色をSQLiteに保存するように修正しました。

cf12f08555d99dfdfcd5909546b82b014c789821 47e97a8c1f02dd9b794e5fef5e6c0432e9d420ab
packetsテーブルにcolorカラムを追加しました。
元々、メモリ上で色を保持するためにTableCustomColorManagerクラスが使われており、色はSQLiteに保存するので、TableCustomColorManagerクラスを無くせると思いましたが、GUIHistoryクラスのprepareRendererの中で毎回SQLiteから色を取りに行くことにすると、パケットが多い時に非常に遅くなったため、TableCustomColorManagerクラスはそのまま残しています。
前回のHistoryを読み込んだ場合 / ファイルを読み込んだ場合 の両方でGUIHistoryクラスのupdateAllAsyncが実行されるため、そこでSQLiteから色をまとめて取り出し、TableCustomColorManagerクラスのインスタンス(colorManager)に載せ、prepareRendererの中ではこれまで通り、colorManagerから色を取るようになっています。

579f7f2ec46574cc137b00edaef3dcac3da31f8d
TableCustomColorManagerクラスでは色を削除した行としてclearedLinesを保持しており、clearedLinesに属する行は全て白色になるようになっていましたが、GUIHistoryクラスのprepareRendererの中で色が設定されていない場合は行番号の偶奇に応じて色を変化させるようになっていたため、clearedLinesは不要かと思い削除しています。デバッグ用のプログラムも使わないかと思い削除しています。もし、余計だったらこのコミットは消します。

d64e433ed6b636696ee258d87c49a8763a9c9aa1
packetsテーブルにcolorカラムを追加したことで、colorカラムを追加する以前のファイルが読み込めなくなるという問題があったため、読み込み時にcolorカラムを追加するようにしています。その場しのぎの実装みたくなってしまっているのですが、他に良い方法が思いつきませんでした...。このコミットも余計だったら消します。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
