### PR TITLE
ResenderタブをSQLiteに保存するように修正

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIData.java
+++ b/src/main/java/core/packetproxy/gui/GUIData.java
@@ -51,7 +51,7 @@ public class GUIData {
 	private TabSet tabs;
 	private JButton resend_button;
 	private JButton resend_multiple_button;
-	private JButton repeater_button;
+	private JButton send_to_resender_button;
 	private JButton copy_url_body_button;
 	private JButton copy_url_button;
 	private JButton copy_body_button;
@@ -190,9 +190,9 @@ public class GUIData {
 			}
 		});
 
-		repeater_button = new JButton("send to Resender");
-		repeater_button.setAlignmentX(0.5f);
-		repeater_button.addActionListener(new ActionListener() {
+		send_to_resender_button = new JButton("send to Resender");
+		send_to_resender_button.setAlignmentX(0.5f);
+		send_to_resender_button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent actionEvent) {
 				try {
@@ -208,7 +208,7 @@ public class GUIData {
 						Packet packet = Packets.getInstance().query(id);
 						packet.setResend();
 						Packets.getInstance().update(packet);
-						GUIRepeater.getInstance().addRepeats(packet.getOneShotPacket(data));
+						GUIResender.getInstance().addResends(packet.getOneShotPacket(data));
 						GUIHistory.getInstance().updateRequestOne(id);
 					}
 				} catch (Exception e1) {
@@ -329,7 +329,7 @@ public class GUIData {
 		button_panel.add(copy_url_button);
 		button_panel.add(resend_button);
 		button_panel.add(resend_multiple_button);
-		button_panel.add(repeater_button);
+		button_panel.add(send_to_resender_button);
 		button_panel.add(new JLabel("  diff: "));
 		button_panel.add(diff_panel);
 		button_panel.setLayout(new BoxLayout(button_panel, BoxLayout.LINE_AXIS));

--- a/src/main/java/core/packetproxy/gui/GUIHistory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistory.java
@@ -413,13 +413,13 @@ public class GUIHistory implements Observer
 			}
 		});
 
-		JMenuItem sendRepeater = createMenuItem ("send to Resender", KeyEvent.VK_R, KeyStroke.getKeyStroke(KeyEvent.VK_R, mask_key), new ActionListener() {
+		JMenuItem sendToResender = createMenuItem ("send to Resender", KeyEvent.VK_R, KeyStroke.getKeyStroke(KeyEvent.VK_R, mask_key), new ActionListener() {
 			public void actionPerformed(ActionEvent actionEvent) {
 				try {
 					Packet packet = gui_packet.getPacket();
 					packet.setResend();
 					Packets.getInstance().update(packet);
-					GUIRepeater.getInstance().addRepeats(packet.getOneShotFromModifiedData());
+					GUIResender.getInstance().addResends(packet.getOneShotFromModifiedData());
 					GUIHistory.getInstance().updateRequestOne(GUIHistory.getInstance().getSelectedPacketId());
 				} catch (Exception e1) {
 					e1.printStackTrace();
@@ -682,7 +682,7 @@ TODO: support --data-binary
 		});
 
 		menu.add(send);
-		menu.add(sendRepeater);
+		menu.add(sendToResender);
 		menu.add(copyAll);
 		menu.add(copy);
 		menu.add(bulkSender);
@@ -731,7 +731,7 @@ TODO: support --data-binary
 							break;
 						case KeyEvent.VK_R:
 							if ((e.getModifiers() & mask_key) == mask_key) {
-								sendRepeater.doClick();
+								sendToResender.doClick();
 							}
 							break;
 						case KeyEvent.VK_M:
@@ -779,7 +779,7 @@ TODO: support --data-binary
 							if (retryCount-- <= 0) {
 								break;
 							}
-							Thread.sleep(100); 
+							Thread.sleep(100);
 							packet = packets.query(packetId);
 						}
 						gui_packet.setPacket(packet);
@@ -794,7 +794,7 @@ TODO: support --data-binary
 
 		JScrollPane scrollpane = new JScrollPane(table);
 		scrollpane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
-		scrollpane.setCorner(JScrollPane.UPPER_RIGHT_CORNER, autoScroll); 
+		scrollpane.setCorner(JScrollPane.UPPER_RIGHT_CORNER, autoScroll);
 
 		split_panel = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
 		split_panel.add(scrollpane);
@@ -812,7 +812,7 @@ TODO: support --data-binary
 	}
 
 	public List<Integer> searchFromRequest(String searchWord) {
-		List<Integer> ids = new ArrayList<Integer>(); 
+		List<Integer> ids = new ArrayList<Integer>();
 		for (int i = 0; i < table.getRowCount(); i++) {
 			String req = (String)tableModel.getValueAt(i, 1);
 			if (req.matches(String.format(".*%s.*", searchWord))) {

--- a/src/main/java/core/packetproxy/gui/GUIHistory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistory.java
@@ -82,6 +82,7 @@ import packetproxy.model.Filters;
 import packetproxy.model.OptionTableModel;
 import packetproxy.model.Packet;
 import packetproxy.model.Packets;
+import packetproxy.model.ResenderPackets;
 import packetproxy.util.CharSetUtility;
 import packetproxy.util.PacketProxyUtility;
 
@@ -142,6 +143,7 @@ public class GUIHistory implements Observer
 	private GUIHistory(boolean restore) throws Exception {
 		packets = Packets.getInstance(restore);
 		packets.addObserver(this);
+		ResenderPackets.getInstance().initTable(restore);
 		Filters.getInstance().addObserver(this);
 		gui_packet = GUIPacket.getInstance();
 		colorManager = new TableCustomColorManager();

--- a/src/main/java/core/packetproxy/gui/GUIMain.java
+++ b/src/main/java/core/packetproxy/gui/GUIMain.java
@@ -44,13 +44,13 @@ public class GUIMain extends JFrame implements Observer
 	private GUIOption gui_option;
 	private GUIHistory gui_history;
 	private GUIIntercept gui_intercept;
-	private GUIRepeater gui_repeater;
+	private GUIResender gui_resender;
 	private GUIBulkSender gui_bulksender;
 	private GUIExtensions gui_extensions;
 	private GUIVulCheckHelper gui_vulcheckhelper;
 	private GUILog gui_log;
 	private InterceptModel interceptModel;
-	public enum Panes {HISTORY, INTERCEPT, REPEATER, VULCHECKHELPER, BULKSENDER, EXTENSIONS, OPTIONS, LOG};
+	public enum Panes {HISTORY, INTERCEPT, RESENDER, VULCHECKHELPER, BULKSENDER, EXTENSIONS, OPTIONS, LOG};
 
 	public static GUIMain getInstance(String title) throws Exception
 	{
@@ -72,14 +72,14 @@ public class GUIMain extends JFrame implements Observer
 	{
 		return this.tabbedpane;
 	}
-	
+
 	private String getPaneString(Panes num) {
 		switch (num) {
 		case HISTORY:
 			return "History";
 		case INTERCEPT:
 			return "Interceptor";
-		case REPEATER:
+		case RESENDER:
 			return "Resender";
 		case VULCHECKHELPER:
 			return "VulCheck Helper";
@@ -108,7 +108,7 @@ public class GUIMain extends JFrame implements Observer
 			gui_option = new GUIOption(this);
 			gui_history = getGUIHistory();
 			gui_intercept = new GUIIntercept(this);
-			gui_repeater = GUIRepeater.getInstance();
+			gui_resender = GUIResender.getInstance();
 			gui_bulksender = GUIBulkSender.getInstance();
 			gui_extensions = GUIExtensions.getInstance();
 			gui_vulcheckhelper = GUIVulCheckHelper.getInstance();
@@ -117,7 +117,7 @@ public class GUIMain extends JFrame implements Observer
 			tabbedpane = new JTabbedPane();
 			tabbedpane.addTab(getPaneString(Panes.HISTORY), gui_history.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.INTERCEPT), gui_intercept.createPanel());
-			tabbedpane.addTab(getPaneString(Panes.REPEATER), gui_repeater.createPanel());
+			tabbedpane.addTab(getPaneString(Panes.RESENDER), gui_resender.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.VULCHECKHELPER), gui_vulcheckhelper.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.BULKSENDER), gui_bulksender.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.EXTENSIONS), gui_extensions.createPanel());
@@ -168,12 +168,11 @@ public class GUIMain extends JFrame implements Observer
 	}
 
 	private void setLookandFeel() throws Exception {
-		
-		if (PacketProxyUtility.getInstance().isUnix()) {	
+		if (PacketProxyUtility.getInstance().isUnix()) {
 			System.setProperty("awt.useSystemAAFontSettings", "on");
 			System.setProperty("swing.aatext", "true");
 		}
-		
+
 		for (LookAndFeelInfo clInfo : UIManager.getInstalledLookAndFeels()) {
 			if ("Nimbus".equals(clInfo.getName())) {
 				UIManager.setLookAndFeel(clInfo.getClassName());
@@ -191,7 +190,7 @@ public class GUIMain extends JFrame implements Observer
 		addShortcutForMac();
 		addDockIconForMac();
 	}
-	
+
 	/**
 	 * Windowsにアイコンを表示する
 	 */
@@ -227,7 +226,7 @@ public class GUIMain extends JFrame implements Observer
 		int hotkey = (KeyEvent.CTRL_MASK | KeyEvent.META_MASK);
 		registerTabShortcut(KeyEvent.VK_H, hotkey, im, am, Panes.HISTORY.ordinal());
 		registerTabShortcut(KeyEvent.VK_I, hotkey, im, am, Panes.INTERCEPT.ordinal());
-		registerTabShortcut(KeyEvent.VK_R, hotkey, im, am, Panes.REPEATER.ordinal());
+		registerTabShortcut(KeyEvent.VK_R, hotkey, im, am, Panes.RESENDER.ordinal());
 		registerTabShortcut(KeyEvent.VK_B, hotkey, im, am, Panes.BULKSENDER.ordinal());
 		registerTabShortcut(KeyEvent.VK_O, hotkey, im, am, Panes.OPTIONS.ordinal());
 		registerTabShortcut(KeyEvent.VK_L, hotkey, im, am, Panes.LOG.ordinal());
@@ -270,7 +269,7 @@ public class GUIMain extends JFrame implements Observer
 		int hotkey = (KeyEvent.CTRL_MASK);
 		registerTabShortcut(KeyEvent.VK_H, hotkey, im, am, Panes.HISTORY.ordinal());
 		registerTabShortcut(KeyEvent.VK_I, hotkey, im, am, Panes.INTERCEPT.ordinal());
-		registerTabShortcut(KeyEvent.VK_R, hotkey, im, am, Panes.REPEATER.ordinal());
+		registerTabShortcut(KeyEvent.VK_R, hotkey, im, am, Panes.RESENDER.ordinal());
 		registerTabShortcut(KeyEvent.VK_B, hotkey, im, am, Panes.BULKSENDER.ordinal());
 		registerTabShortcut(KeyEvent.VK_O, hotkey, im, am, Panes.OPTIONS.ordinal());
 		registerTabShortcut(KeyEvent.VK_L, hotkey, im, am, Panes.LOG.ordinal());

--- a/src/main/java/core/packetproxy/gui/GUIMenu.java
+++ b/src/main/java/core/packetproxy/gui/GUIMenu.java
@@ -41,7 +41,7 @@ public class GUIMenu extends JMenuBar {
 	final static private String defaultDir = System.getProperty("user.home");
 	GUIMenu self;
 	JFrame owner;
-	private enum Panes {HISTORY, INTERCEPT, REPEATER, BULKSENDER, OPTIONS, LOG};
+	private enum Panes {HISTORY, INTERCEPT, RESENDER, BULKSENDER, OPTIONS, LOG};
 	public GUIMenu(JFrame owner) {
 		self = this;
 		this.owner = owner;
@@ -159,20 +159,20 @@ public class GUIMenu extends JMenuBar {
 					e1.printStackTrace();
 				}
 			}
-		});		
-		JMenuItem view_repeater = new JMenuItem(I18nString.get("View Resender")+"  "+cmd_key+"R");
-		view_menu.add(view_repeater);
-		view_repeater.addActionListener(new ActionListener() {
+		});
+		JMenuItem view_resender = new JMenuItem(I18nString.get("View Resender")+"  "+cmd_key+"R");
+		view_menu.add(view_resender);
+		view_resender.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				try {
-					GUIMain.getInstance().getTabbedPane().setSelectedIndex(Panes.REPEATER.ordinal());
+					GUIMain.getInstance().getTabbedPane().setSelectedIndex(Panes.RESENDER.ordinal());
 
 				} catch (Exception e1) {
-					e1.printStackTrace();	
+					e1.printStackTrace();
 				}
 			}
-		});		
+		});
 		JMenuItem view_bulk_sender = new JMenuItem(I18nString.get("View BulkSender")+"  "+cmd_key+"B");
 		view_menu.add(view_bulk_sender);
 		view_bulk_sender.addActionListener(new ActionListener() {
@@ -184,7 +184,7 @@ public class GUIMenu extends JMenuBar {
 					e1.printStackTrace();
 				}
 			}
-		});		
+		});
 		JMenuItem view_options = new JMenuItem(I18nString.get("View Options")+"  "+cmd_key+"O");
 		view_menu.add(view_options);
 		view_options.addActionListener(new ActionListener() {

--- a/src/main/java/core/packetproxy/gui/GUIPacketData.java
+++ b/src/main/java/core/packetproxy/gui/GUIPacketData.java
@@ -67,7 +67,7 @@ public class GUIPacketData
 	}
 
 	public OneShotPacket getOneShotPacket() {
-		byte[] data = tabs.getData(); 
+		byte[] data = tabs.getData();
 		if (data != null) {
 			showing_packet.setData(data);
 		}
@@ -84,9 +84,5 @@ public class GUIPacketData
 
 	public void setParentSend(JButton parentSend) {
 		tabs.setParentSend (parentSend);
-	}
-
-	public void setParentSendRepeater(JButton parentSendRepeater) {
-		tabs.setParentSendRepeater (parentSendRepeater);
 	}
 }

--- a/src/main/java/core/packetproxy/gui/GUIResender.java
+++ b/src/main/java/core/packetproxy/gui/GUIResender.java
@@ -37,30 +37,30 @@ import packetproxy.controller.ResendController;
 import packetproxy.controller.ResendController.ResendWorker;
 import packetproxy.model.OneShotPacket;
 
-public class GUIRepeater
+public class GUIResender
 {
 	private JPanel main_panel;
-	private CloseButtonTabbedPane repeat_tab;
-	private List<Repeats> list;
+	private CloseButtonTabbedPane resend_tab;
+	private List<Resends> list;
 	private int previousTabIndex;
 
-	private static GUIRepeater instance;
-	
-	public static GUIRepeater getInstance() throws Exception {
+	private static GUIResender instance;
+
+	public static GUIResender getInstance() throws Exception {
 		if (instance == null) {
-			instance = new GUIRepeater();
+			instance = new GUIResender();
 		}
 		return instance;
 	}
 
-	private GUIRepeater() {
+	private GUIResender() {
 		main_panel = new JPanel();
-		repeat_tab = new CloseButtonTabbedPane();
-		previousTabIndex = repeat_tab.getSelectedIndex();
-		repeat_tab.addChangeListener(new ChangeListener() {
+		resend_tab = new CloseButtonTabbedPane();
+		previousTabIndex = resend_tab.getSelectedIndex();
+		resend_tab.addChangeListener(new ChangeListener() {
 			@Override
 			public void stateChanged(ChangeEvent e) {
-				int currentTabIndex = repeat_tab.getSelectedIndex();
+				int currentTabIndex = resend_tab.getSelectedIndex();
 				if(previousTabIndex<0){
 					previousTabIndex = currentTabIndex;
 					return;
@@ -69,41 +69,41 @@ public class GUIRepeater
 			}
 		});
 		main_panel.setLayout(new BoxLayout(main_panel, BoxLayout.Y_AXIS));
-		main_panel.add(repeat_tab);
-		list = new ArrayList<Repeats>();
+		main_panel.add(resend_tab);
+		list = new ArrayList<Resends>();
 	}
-	
+
 	public JComponent createPanel() {
 		return main_panel;
 	}
-	
-	public void addRepeats(OneShotPacket send_packet) throws Exception {
-		Repeats repeats = new Repeats(this);
-		list.add(repeats);
-		repeat_tab.addTab(String.valueOf(list.size()+1), repeats.getComponent());
-		repeat_tab.setSelectedComponent(repeats.getComponent());
-		repeats.addRepeat(send_packet, null);
+
+	public void addResends(OneShotPacket send_packet) throws Exception {
+		Resends resends = new Resends(this);
+		list.add(resends);
+		resend_tab.addTab(String.valueOf(list.size()+1), resends.getComponent());
+		resend_tab.setSelectedComponent(resends.getComponent());
+		resends.addResend(send_packet, null);
 	}
-	
-	public Repeats get(int index) {
+
+	public Resends get(int index) {
 		return list.get(index);
 	}
-	
-	class Repeats {
-		private GUIRepeater parent;
+
+	class Resends {
+		private GUIResender parent;
 		private JPanel main_panel;
-		private CloseButtonTabbedPane repeat_tab;
-		private List<Repeat> list;
+		private CloseButtonTabbedPane resend_tab;
+		private List<Resend> list;
 		private int previousTabIndex;
-		
-		public Repeats(GUIRepeater parent) {
+
+		public Resends(GUIResender parent) {
 			this.parent = parent;
-			repeat_tab = new CloseButtonTabbedPane();
-			previousTabIndex = repeat_tab.getSelectedIndex();
-			repeat_tab.addChangeListener(new ChangeListener() {
+			resend_tab = new CloseButtonTabbedPane();
+			previousTabIndex = resend_tab.getSelectedIndex();
+			resend_tab.addChangeListener(new ChangeListener() {
 				@Override
 				public void stateChanged(ChangeEvent e) {
-					int currentTabIndex = repeat_tab.getSelectedIndex();
+					int currentTabIndex = resend_tab.getSelectedIndex();
 					if(previousTabIndex<0){
 						previousTabIndex = currentTabIndex;
 						return;
@@ -113,19 +113,19 @@ public class GUIRepeater
 			});
 		    main_panel = new JPanel();
 			main_panel.setLayout(new BoxLayout(main_panel, BoxLayout.Y_AXIS));
-			main_panel.add(repeat_tab);
-			list = new ArrayList<Repeat>();
+			main_panel.add(resend_tab);
+			list = new ArrayList<Resend>();
 		}
 
-		public void addRepeat(OneShotPacket send_packet, OneShotPacket recv_packet) throws Exception {
-			Repeat repeat = new Repeat(this);
-			list.add(repeat);
-			repeat_tab.addTab(String.valueOf(list.size() + 1), repeat.getComponent());
-			repeat_tab.setSelectedComponent(repeat.getComponent());
-			repeat.setOneShotPacket(send_packet, recv_packet);
+		public void addResend(OneShotPacket send_packet, OneShotPacket recv_packet) throws Exception {
+			Resend resend = new Resend(this);
+			list.add(resend);
+			resend_tab.addTab(String.valueOf(list.size() + 1), resend.getComponent());
+			resend_tab.setSelectedComponent(resend.getComponent());
+			resend.setOneShotPacket(send_packet, recv_packet);
 		}
 
-		public Repeat get(int index) {
+		public Resend get(int index) {
 			return list.get(index);
 		}
 
@@ -133,8 +133,8 @@ public class GUIRepeater
 			return main_panel;
 		}
 	}
-	
-	class Repeat implements Observer {
+
+	class Resend implements Observer {
 		private GUIServerNamePanel server_name_panel;
 		private OneShotPacket send_saved;
 		private OneShotPacket recv_saved;
@@ -145,8 +145,7 @@ public class GUIRepeater
 		private JButton resend_multiple_button;
 		private JPanel main_panel;
 
-		public Repeat(Repeats parent) throws Exception {
-		
+		public Resend(Resends parent) throws Exception {
 			server_name_panel = new GUIServerNamePanel();
 			send_panel = new GUIPacketData();
 			recv_panel = new GUIPacketData();
@@ -171,7 +170,7 @@ public class GUIRepeater
 								try {
 									OneShotPacket recvPacket = packets.get(0);
 									recv_panel.setOneShotPacket(recvPacket);
-									parent.addRepeat(sendPacket, recvPacket);
+									parent.addResend(sendPacket, recvPacket);
 									rollback();
 								} catch (Exception e) {
 									e.printStackTrace();
@@ -184,7 +183,7 @@ public class GUIRepeater
 				}
 			});
 			send_panel.setParentSend(resend_button);
-		
+
 		    resend_multiple_button = new JButton("send x 20");
 			resend_multiple_button.addActionListener(new ActionListener() {
 				@Override
@@ -199,12 +198,12 @@ public class GUIRepeater
 					}
 				}
 			});
-			
+
 		    JPanel button_panel = new JPanel();
 			button_panel.add(resend_button);
 			button_panel.add(resend_multiple_button);
 		    button_panel.setMaximumSize(new Dimension(Short.MAX_VALUE, 10));
-		
+
 		    main_panel = new JPanel();
 			main_panel.setLayout(new BoxLayout(main_panel, BoxLayout.Y_AXIS));
 			main_panel.add(server_name_panel);
@@ -216,7 +215,7 @@ public class GUIRepeater
 			log += "\n";
 			recv_panel.appendData(log.getBytes());
 		}
-		
+
 		private void clearLog() throws Exception {
 			recv_panel.setData("".getBytes());
 		}
@@ -224,7 +223,7 @@ public class GUIRepeater
 		public JComponent getComponent() {
 			return main_panel;
 		}
-		
+
 		public void rollback() throws Exception {
 			send_panel.setOneShotPacket(send_saved == null ? null : (OneShotPacket)send_saved.clone());
 			recv_panel.setOneShotPacket(recv_saved == null ? null : (OneShotPacket)recv_saved.clone());

--- a/src/main/java/core/packetproxy/gui/RawTextPane.java
+++ b/src/main/java/core/packetproxy/gui/RawTextPane.java
@@ -54,68 +54,12 @@ public class RawTextPane extends ExtendedTextPane
 
 	public RawTextPane() throws Exception {
 		charSetUtility = CharSetUtility.getInstance();
-		
+
 		int mask_key = ActionEvent.META_MASK;
 		if (!PacketProxyUtility.getInstance().isMac()) {
 			mask_key = ActionEvent.CTRL_MASK;
 		}
 		JPopupMenu menu = new JPopupMenu();
-
-		JMenuItem send = new JMenuItem("send");
-		send.setMnemonic(KeyEvent.VK_S);
-		send.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, mask_key));
-		send.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent actionEvent) {
-				try {
-					JButton parentSend = getParentSend();
-					if (parentSend != null) {
-						parentSend.doClick();
-					} else {
-						Packet packet = GUIPacket.getInstance().getPacket();
-						ResendController.getInstance().resend(packet.getOneShotPacket(getData()));
-						packet.setSentData(getData());
-						packet.setResend();
-						Packets.getInstance().update(packet);
-						GUIHistory.getInstance().updateRequestOne(GUIHistory.getInstance().getSelectedPacketId());
-					}
-				} catch (Exception e1) {
-					e1.printStackTrace();
-				}
-			}
-		});
-		menu.add(send);
-
-		JMenuItem sendBulkSender = new JMenuItem("send to BulkSender");
-		sendBulkSender.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent actionEvent) {
-				try {
-					Packet packet = GUIPacket.getInstance().getPacket();
-					GUIBulkSender.getInstance().add(packet.getOneShotPacket(getData()), packet.getId());
-					GUIHistory.getInstance().updateRequestOne(GUIHistory.getInstance().getSelectedPacketId());
-				} catch (Exception e1) {
-					e1.printStackTrace();
-				}
-			}
-		});
-		menu.add(sendBulkSender);
-
-		JMenuItem sendRepeater = new JMenuItem("send to Resender");
-		sendRepeater.setMnemonic(KeyEvent.VK_R);
-		sendRepeater.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, mask_key));
-		sendRepeater.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent actionEvent) {
-				try {
-					Packet packet = GUIPacket.getInstance().getPacket();
-					packet.setResend();
-					Packets.getInstance().update(packet);
-					GUIRepeater.getInstance().addRepeats(packet.getOneShotPacket(getData()));
-					GUIHistory.getInstance().updateRequestOne(GUIHistory.getInstance().getSelectedPacketId());
-				} catch (Exception e1) {
-					e1.printStackTrace();
-				}
-			}
-		});
-		menu.add(sendRepeater);
 
 		addKeyListener(new KeyAdapter() {
 			public void keyPressed(KeyEvent e) {
@@ -143,21 +87,10 @@ public class RawTextPane extends ExtendedTextPane
 							e.consume();
 						}
 						break;
-					case KeyEvent.VK_S:
-						if ((e.getModifiers() & mask_key) == mask_key) {
-							send.doClick();
-						}
-						break;
-					case KeyEvent.VK_R:
-						if ((e.getModifiers() & mask_key) == mask_key) {
-							sendRepeater.doClick();
-						}
-						break;
 				}
 			}
 		});
 
-		menu.addSeparator();
 		JMenuItem vulCheckers = new JMenuItem(I18nString.get("VulCheck Helpers"));
 		vulCheckers.setFont(FontManager.getInstance().getUICaptionFont());
 		vulCheckers.setEnabled(false);

--- a/src/main/java/core/packetproxy/gui/TabSet.java
+++ b/src/main/java/core/packetproxy/gui/TabSet.java
@@ -39,7 +39,6 @@ public class TabSet extends Observable {
 	private JComponent json_text;
 	private JButton copyButton = null;
 	private JButton parentSend = null;
-	private JButton parentSendRepeater = null;
 	private byte[] data;
 	private Range emphasis;
 
@@ -142,14 +141,6 @@ public class TabSet extends Observable {
 
 	public void setParentSend (JButton parentSend) {
 		this.parentSend = parentSend;
-	}
-
-	public JButton getParentSendRepeater () {
-		return parentSendRepeater;
-	}
-
-	public void setParentSendRepeater (JButton parentSendRepeater) {
-		this.parentSendRepeater = parentSendRepeater;
 	}
 
 	private void update() {

--- a/src/main/java/core/packetproxy/model/Database.java
+++ b/src/main/java/core/packetproxy/model/Database.java
@@ -97,7 +97,7 @@ public class Database extends Observable
 
 		setChanged();
 		notifyObservers(DatabaseMessage.RECONNECT);
-		clearChanged();	
+		clearChanged();
 	}
 
 	public void dropConfigs() throws Exception {
@@ -141,6 +141,7 @@ public class Database extends Observable
 		createTable(Modification.class, Modifications.getInstance());
 		createTable(SSLPassThrough.class, SSLPassThroughs.getInstance());
 		createTable(CharSet.class, CharSets.getInstance());
+		createTable(ResenderPacket.class, ResenderPackets.getInstance());
 		notifyObservers(DatabaseMessage.RECREATE);
 
 		migrateTableWithoutHistory(src, dst);
@@ -176,6 +177,7 @@ public class Database extends Observable
 					"INSERT OR REPLACE INTO dstDB.modifications (id, enabled, server_id, direction, pattern, method, replaced) SELECT id, enabled, server_id, direction, pattern, method, replaced FROM srcDB.modifications",
 					"INSERT OR REPLACE INTO dstDB.sslpassthroughs (id, enabled, server_name, listen_port) SELECT id, enabled, server_name, listen_port FROM srcDB.sslpassthroughs",
 					"INSERT OR REPLACE INTO dstDB.charsets (id, charsetname) SELECT id, charsetname FROM srcDB.charsets",
+					"INSERT OR REPLACE INTO dstDB.resender_packets (id, resends_index, resend_index, direction, data, listen_port, client_ip, client_port, server_ip, server_port, server_name, use_ssl, encoder_name, alpn, auto_modified, conn, `group`) SELECT id, resends_index, resend_index, direction, data, listen_port, client_ip, client_port, server_ip, server_port, server_name, use_ssl, encoder_name, alpn, auto_modified, conn, `group` FROM srcDB.resender_packets",
 			};
 			for (String query : queries){
 				try {

--- a/src/main/java/core/packetproxy/model/OneShotPacket.java
+++ b/src/main/java/core/packetproxy/model/OneShotPacket.java
@@ -147,7 +147,7 @@ public class OneShotPacket implements PacketInfo, Cloneable
 	public long getGroup() {
 		return this.group;
 	}
-	public void encode(){    	
+	public void encode(){
 	}
 	public Packet toPacket() throws Exception {
 		Packet packet = new Packet(listen_port, client_ip, client_port, server_ip, server_port, server_name, use_ssl, encoder_name, alpn, direction, conn, group);
@@ -169,5 +169,9 @@ public class OneShotPacket implements PacketInfo, Cloneable
 			encoder = EncoderManager.getInstance().createInstance("Sample", alpn);
 		}
 		return (getDirection() == Direction.SERVER) ? encoder.getSummarizedResponse(toPacket()) : "";
+	}
+	public ResenderPacket getResenderPacket(int resends_index, int resend_index) throws Exception {
+		ResenderPacket resenderPacket = new ResenderPacket(resends_index, resend_index, direction, data, listen_port, client_ip, client_port, server_ip, server_port, server_name, use_ssl, encoder_name, alpn, auto_modified, conn, group);
+		return resenderPacket;
 	}
 }

--- a/src/main/java/core/packetproxy/model/ResenderPacket.java
+++ b/src/main/java/core/packetproxy/model/ResenderPacket.java
@@ -1,0 +1,85 @@
+package packetproxy.model;
+
+import java.net.InetSocketAddress;
+
+import com.j256.ormlite.field.DataType;
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+
+@DatabaseTable(tableName = "resender_packets")
+public class ResenderPacket {
+	@DatabaseField(generatedId = true)
+	private int id;
+	@DatabaseField(uniqueCombo = true)
+	private int resends_index; // 上側のタブの番号
+	@DatabaseField(uniqueCombo = true)
+	private int resend_index; // 下側のタブの番号
+	@DatabaseField(dataType = DataType.ENUM_STRING, uniqueCombo = true)
+	private Packet.Direction direction;
+	@DatabaseField(dataType = DataType.BYTE_ARRAY)
+	private byte[] data;
+	@DatabaseField
+	private int listen_port;
+	@DatabaseField
+	private String client_ip;
+	@DatabaseField
+	private int client_port;
+	@DatabaseField
+	private String server_ip;
+	@DatabaseField
+	private int server_port;
+	@DatabaseField
+	private String server_name;
+	@DatabaseField
+	private boolean use_ssl;
+	@DatabaseField
+	private String encoder_name;
+	@DatabaseField
+	private String alpn;
+	@DatabaseField
+	private boolean auto_modified;
+	@DatabaseField
+	private int conn;
+	@DatabaseField
+	private long group;
+
+	public ResenderPacket() {
+		// ORMLite needs a no-arg constructor
+	}
+
+	public ResenderPacket(int resends_index, int resend_index, Packet.Direction direction, byte[] data, int listen_port, String client_ip, int client_port, String server_ip, int server_port, String server_name, boolean use_ssl, String encoder_name, String alpn, boolean auto_modified, int conn, long group) {
+		this.resends_index = resends_index;
+		this.resend_index = resend_index;
+		this.direction = direction;
+		this.data = data;
+		this.listen_port = listen_port;
+		this.client_ip = client_ip;
+		this.client_port = client_port;
+		this.server_ip = server_ip;
+		this.server_port = server_port;
+		this.server_name = server_name;
+		this.use_ssl = use_ssl;
+		this.encoder_name = encoder_name;
+		this.alpn = alpn;
+		this.auto_modified = auto_modified;
+		this.conn = conn;
+		this.group = group;
+	}
+
+	public int getResendsIndex() {
+		return this.resends_index;
+	}
+
+	public int getResendIndex() {
+		return this.resend_index;
+	}
+
+	public Packet.Direction getDirection() {
+		return this.direction;
+	}
+
+	public OneShotPacket getOneShotPacket() {
+		OneShotPacket oneShotPacket = new OneShotPacket(-1, listen_port, new InetSocketAddress(client_ip, client_port), new InetSocketAddress(server_ip, server_port), server_name, use_ssl, data, encoder_name, alpn, direction, conn, group);
+		return oneShotPacket;
+	}
+}

--- a/src/main/java/core/packetproxy/model/ResenderPackets.java
+++ b/src/main/java/core/packetproxy/model/ResenderPackets.java
@@ -1,0 +1,115 @@
+package packetproxy.model;
+
+import java.util.List;
+import java.util.Observable;
+import java.util.Observer;
+
+import javax.swing.JOptionPane;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.stmt.DeleteBuilder;
+
+import packetproxy.model.Database.DatabaseMessage;
+
+public class ResenderPackets extends Observable implements Observer {
+	private static ResenderPackets instance;
+
+	public static ResenderPackets getInstance() throws Exception {
+		if (instance == null) {
+			instance = new ResenderPackets();
+		}
+		return instance;
+	}
+
+	private Database database;
+	private Dao<ResenderPacket, Integer> dao;
+
+	private ResenderPackets() throws Exception {
+		database = Database.getInstance();
+		dao = database.createTable(ResenderPacket.class, this);
+	}
+
+	public void initTable(boolean restore) throws Exception {
+		if (restore) {
+			if (!isLatestVersion()) {
+				RecreateTable();
+			}
+		} else {
+			database.dropTable(ResenderPacket.class);
+			database.createTable(ResenderPacket.class, this);
+		}
+	}
+
+	public void createResend(ResenderPacket resenderPacket) throws Exception {
+		dao.create(resenderPacket);
+	}
+
+	public void deleteResends(int resends_index) throws Exception {
+		DeleteBuilder<ResenderPacket, Integer> deleteBuilder = dao.deleteBuilder();
+		deleteBuilder.where().eq("resends_index", resends_index);
+		dao.delete(deleteBuilder.prepare());
+	}
+
+	public void deleteResend(int resends_index, int resend_index) throws Exception {
+	   DeleteBuilder<ResenderPacket, Integer> deleteBuilder = dao.deleteBuilder();
+	   deleteBuilder.where().eq("resends_index", resends_index).and().eq("resend_index", resend_index);
+	   dao.delete(deleteBuilder.prepare());
+	}
+
+	public List<ResenderPacket> queryAllOrdered() throws Exception {
+		return dao.queryBuilder().orderBy("resends_index", true).orderBy("resend_index", true).query();
+	}
+
+	@Override
+	public void notifyObservers(Object arg) {
+		setChanged();
+		super.notifyObservers(arg);
+		clearChanged();
+	}
+
+	@Override
+	public void update(Observable o, Object arg) {
+		DatabaseMessage message = (DatabaseMessage) arg;
+		try {
+			switch (message) {
+				case PAUSE:
+					// TODO ロックを取る
+					break;
+				case RESUME:
+					// TODO ロックを解除
+					break;
+				case DISCONNECT_NOW:
+					break;
+				case RECONNECT:
+					database = Database.getInstance();
+					dao = database.createTable(ResenderPacket.class, this);
+					notifyObservers(arg);
+					break;
+				case RECREATE:
+					database = Database.getInstance();
+					dao = database.createTable(ResenderPacket.class, this);
+					break;
+				default:
+					break;
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private boolean isLatestVersion() throws Exception {
+		String result = dao.queryRaw("SELECT sql FROM sqlite_master WHERE name='resender_packets'").getFirstResult()[0];
+		return result.equals("CREATE TABLE `resender_packets` (`id` INTEGER PRIMARY KEY AUTOINCREMENT , `resends_index` INTEGER , `resend_index` INTEGER , `direction` VARCHAR , `data` BLOB , `listen_port` INTEGER , `client_ip` VARCHAR , `client_port` INTEGER , `server_ip` VARCHAR , `server_port` INTEGER , `server_name` VARCHAR , `use_ssl` BOOLEAN , `encoder_name` VARCHAR , `alpn` VARCHAR , `auto_modified` BOOLEAN , `conn` INTEGER , `group` BIGINT , UNIQUE (`resends_index`,`resend_index`,`direction`) )");
+	}
+
+	private void RecreateTable() throws Exception {
+		int option = JOptionPane.showConfirmDialog(null,
+				"resender_packetsテーブルの形式が更新されているため\n現在のテーブルを削除して再起動しても良いですか？",
+				"テーブルの更新",
+				JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+		if (option == JOptionPane.YES_OPTION) {
+			database.dropTable(ResenderPacket.class);
+			dao = database.createTable(ResenderPacket.class, this);
+		}
+	}
+}


### PR DESCRIPTION
88b23cfa8d1f469c38e7d2eb1aaef07e89bf92ca
Rawタブでsend to Resenderを選択した時、送信内容はRawタブのものが使われますが、リクエストの送信先やエンコードモジュールは、Historyタブで選択しているリクエストのものが使われるようになっています。

https://github.com/DeNA/PacketProxy/blob/39ba3f0e7fb82c7d790cac8e595e0729b76e084e/src/main/java/core/packetproxy/gui/RawTextPane.java#L102-L117

https://github.com/DeNA/PacketProxy/blob/39ba3f0e7fb82c7d790cac8e595e0729b76e084e/src/main/java/core/packetproxy/model/Packet.java#L117-L132

そのため、例えば、Resenderタブ中のRawタブでsend to Resenderを選択した場合、意図しない送信先にリクエストが送信されたり、意図しないエンコードモジュールが使われる可能性があります。send to Resenderの他にも、send, send to BulkSenderも同様です。

修正するためには、Rawタブを使用しているInterceptorタブ、Resenderタブ、VulCheck Helperタブ、Bulk Senderタブ、それぞれで個別に処理を行う必要があり、複雑な修正内容になってしまうため、Rawタブ上では、send, send to BulkSender, send to Resenderを選択出来ないようにしました。これまで通り、Historyタブのリクエスト一覧からは、send, send to BulkSender, send to Resenderを選択出来ます。

6b44de9534b9368d1c00c827060587fb22074260
プログラム中でrepeatとresendが混在していたため、resendに統一しました。

4fd2b9ba1d943b022cd4e5c0d586cd7a990167d5
ResenderタブをSQLiteに保存するようにし、「前回のHistoryを読み込みますか？」→「はい」とした時と、ファイルを読み込んだ時にResenderタブが復元されるようにしました。

resender_packetsという名前のテーブルを作成し、Resenderタブのリクエスト/レスポンスを保持しています。
Resenderタブでは、OneShotPacket(model/OneShotPacket.java)を扱っていたため、resender_packetsテーブルに保存する用のResenderPacket(model/ResenderPacket.java)を作成し、OneShotPacketからResenderPacketに変換して、resender_packetsテーブルに保存しています。その逆で、resender_packetsテーブルから取り出したResenderPacketをOneShotPacketに変換している部分もあります。

ResenderPacketが持つフィールドは、OneShotPacketとほとんど同じですが、ResenderPacketには、resends_indexとresend_indexというフィールドが存在します。Resenderタブにおける上側のタブの番号がresends_indexで、下側のタブの番号がresend_indexです(下の画像の場合、resends_indexが2で、resend_indexが3です)。

<img width="500" alt="スクリーンショット 2024-07-08 17 32 47" src="https://github.com/DeNA/PacketProxy/assets/61813626/01b5cf64-46bf-4276-bcff-e66184db9e42">

Resenderタブ(gui/GUIResender.java)では、上側のタブ一覧(resends_tabs)と上側のタブ番号の一覧(resends_indexes)、上側のタブそれぞれについて、下側のタブ一覧(resend_tabs)と下側のタブ番号の一覧(resend_indexes)を管理しています。loadResenderPacketsメソッドは、Resenderタブの初期化時とファイル読み込み時に呼ばれるメソッドで、resender_packetsテーブルから(resends_index, resend_index)の昇順にレコードを取り出し、順番に処理しています。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
