### PR TITLE
send to Resender, send to Bulk Sender周りのバグ修正、改善

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIHistory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistory.java
@@ -421,7 +421,11 @@ public class GUIHistory implements Observer
 					Packet packet = gui_packet.getPacket();
 					packet.setResend();
 					Packets.getInstance().update(packet);
-					GUIResender.getInstance().addResends(packet.getOneShotFromModifiedData());
+					if (packet.getModifiedData().length == 0) { // dropしたパケットの場合
+						GUIResender.getInstance().addResends(packet.getOneShotFromDecodedData());
+					} else {
+						GUIResender.getInstance().addResends(packet.getOneShotFromModifiedData());
+					}
 					GUIHistory.getInstance().updateRequestOne(GUIHistory.getInstance().getSelectedPacketId());
 				} catch (Exception e1) {
 					e1.printStackTrace();
@@ -470,7 +474,12 @@ public class GUIHistory implements Observer
 		JMenuItem bulkSender = createMenuItem ("send to Bulk Sender", -1, null, new ActionListener() {
 			public void actionPerformed(ActionEvent actionEvent) {
 				try {
-					GUIBulkSender.getInstance().add(gui_packet.getPacket().getOneShotFromModifiedData(), gui_packet.getPacket().getId());
+					Packet packet = gui_packet.getPacket();
+					if (packet.getModifiedData().length == 0) { // dropしたパケットの場合
+						GUIBulkSender.getInstance().add(packet.getOneShotFromDecodedData(), packet.getId());
+					} else {
+						GUIBulkSender.getInstance().add(packet.getOneShotFromModifiedData(), packet.getId());
+					}
 				} catch (Exception e) {
 					e.printStackTrace();
 				}

--- a/src/main/java/core/packetproxy/gui/GUIIntercept.java
+++ b/src/main/java/core/packetproxy/gui/GUIIntercept.java
@@ -38,6 +38,7 @@ import javax.swing.KeyStroke;
 import packetproxy.controller.InterceptController;
 import packetproxy.model.InterceptModel;
 import packetproxy.model.Packet;
+import packetproxy.model.Packets;
 import packetproxy.util.PacketProxyUtility;
 
 public class GUIIntercept implements Observer
@@ -46,6 +47,8 @@ public class GUIIntercept implements Observer
 	private JButton forward_button;
 	private JButton forward_multi_button;
 	private JButton drop_button;
+	private JButton send_to_resender_button;
+	private JButton send_to_bulk_sender_button;
 	private JToggleButton forward_enable;
 	private InterceptModel interceptModel;
 	private InterceptController intercept_controller;
@@ -98,11 +101,39 @@ public class GUIIntercept implements Observer
 				try { intercept_controller.drop(); } catch (Exception e1) { e1.printStackTrace(); }
 			}
 		});
+		send_to_resender_button = new JButton("send to Resender");
+		send_to_resender_button.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				try {
+					Packet packet = InterceptModel.getInstance().getClientPacket();
+					packet.setResend();
+					Packets.getInstance().update(packet);
+					GUIResender.getInstance().addResends(packet.getOneShotPacket(getInterceptData()));
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		});
+		send_to_bulk_sender_button = new JButton("send to Bulk Sender");
+		send_to_bulk_sender_button.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				try {
+					Packet packet = InterceptModel.getInstance().getClientPacket();
+					GUIBulkSender.getInstance().add(packet.getOneShotPacket(getInterceptData()), packet.getId());
+				} catch (Exception e1) {
+					e1.printStackTrace();
+				}
+			}
+		});
 		JPanel button_panel = new JPanel();
 		button_panel.add(forward_enable);
 		button_panel.add(forward_button);
 		button_panel.add(forward_multi_button);
 		button_panel.add(drop_button);
+		button_panel.add(send_to_resender_button);
+		button_panel.add(send_to_bulk_sender_button);
 		button_panel.setMaximumSize(new Dimension(1000, 10));
 		button_panel.setAlignmentX(0.5f);
 
@@ -157,7 +188,7 @@ public class GUIIntercept implements Observer
 	private byte[] getInterceptData() {
 		byte[] data = null;
 		int index = tabs.getSelectedIndex();
-		if (index == 0) { 
+		if (index == 0) {
 			if (Arrays.equals(raw_original_data, tabs.getRaw().getData())) {
 				data = original_data;
 			} else {

--- a/src/main/java/core/packetproxy/gui/GUIIntercept.java
+++ b/src/main/java/core/packetproxy/gui/GUIIntercept.java
@@ -81,6 +81,7 @@ public class GUIIntercept implements Observer
 			cmd_key="Ctrl+";
 		}
 		forward_button = new JButton("forward "+cmd_key+"F");
+		forward_button.setEnabled(false);
 		forward_button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent actionEvent) {
@@ -88,6 +89,7 @@ public class GUIIntercept implements Observer
 			}
 		});
 		forward_multi_button = new JButton("forward x 20");
+		forward_multi_button.setEnabled(false);
 		forward_multi_button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -95,6 +97,7 @@ public class GUIIntercept implements Observer
 			}
 		});
 		drop_button = new JButton("drop "+cmd_key+"D");
+		drop_button.setEnabled(false);
 		drop_button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -102,6 +105,7 @@ public class GUIIntercept implements Observer
 			}
 		});
 		send_to_resender_button = new JButton("send to Resender");
+		send_to_resender_button.setEnabled(false);
 		send_to_resender_button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -116,6 +120,7 @@ public class GUIIntercept implements Observer
 			}
 		});
 		send_to_bulk_sender_button = new JButton("send to Bulk Sender");
+		send_to_bulk_sender_button.setEnabled(false);
 		send_to_bulk_sender_button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -213,6 +218,26 @@ public class GUIIntercept implements Observer
 			Packet client_packet = interceptModel.getClientPacket();
 			Packet server_packet = interceptModel.getServerPacket();
 			setInterceptData(data, client_packet, server_packet);
+
+			if (client_packet == null && server_packet == null) { // パケットが来ていない時
+				forward_button.setEnabled(false);
+				forward_multi_button.setEnabled(false);
+				drop_button.setEnabled(false);
+				send_to_resender_button.setEnabled(false);
+				send_to_bulk_sender_button.setEnabled(false);
+			} else if (server_packet == null) { // クライアントからサーバへのパケットの表示時
+				forward_button.setEnabled(true);
+				forward_multi_button.setEnabled(true);
+				drop_button.setEnabled(true);
+				send_to_resender_button.setEnabled(true);
+				send_to_bulk_sender_button.setEnabled(true);
+			} else { // サーバからクライアントへのパケット表示時
+				forward_button.setEnabled(true);
+				forward_multi_button.setEnabled(false);
+				drop_button.setEnabled(true);
+				send_to_resender_button.setEnabled(false);
+				send_to_bulk_sender_button.setEnabled(false);
+			}
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/core/packetproxy/model/Packet.java
+++ b/src/main/java/core/packetproxy/model/Packet.java
@@ -184,6 +184,21 @@ public class Packet implements PacketInfo
 	public byte[] getDecodedData() {
 		return this.decoded_data == null ? new byte[]{} : this.decoded_data;
 	}
+	public OneShotPacket getOneShotFromDecodedData() {
+		return new OneShotPacket(
+				getId(),
+				getListenPort(),
+				getClient(),
+				getServer(),
+				getServerName(),
+				getUseSSL(),
+				getDecodedData(),
+				getEncoder(),
+				getAlpn(),
+				getDirection(),
+				getConn(),
+				getGroup());
+	}
 	public void setModified() {
 		this.modified = true;
 	}


### PR DESCRIPTION
2174fdf2189c08cd98b064df02001c8ca6e0ea38
Interceptorで捕まえてdropしたパケットをsend to Resender, send to Bulk Senderすると、以下のように内容が空のパケットが作られてしまうバグがありました。

<img width="350" src="https://github.com/user-attachments/assets/7ce9af18-6e10-44ce-9d38-8ae06bc16dff">

<img width="350" src="https://github.com/user-attachments/assets/645f4f08-367a-411f-8955-a076d0551367">

send to Resender, send to Bulk Senderをする時に、Modifiedのデータが対象にされていますが、dropしたパケットについてはModifiedのデータが空であることが原因でした。そのため、Modifiedのデータが空だったら、Decodedのデータを対象にするように修正しています。

87576720e3832c8dbc1790864c7483b2f8d8b64a
#165 でRawタブでsend to Resender, send to Bulk Senderを出来ないようにしたのですが、Interceptorからsend to Resender, send to Bulk Senderが出来ないのは少し不便な気がしたので、出来るように修正しました。
Rawタブからsend to Resender, send to Bulk Senderを出来るようにするのは難しかったため、Interceptorで表示するボタンにsend to Resender, send to Bulk Senderを追加しました。

<img width="350" src="https://github.com/user-attachments/assets/c66ee28e-acce-475e-b037-960b2404f493">

86664d094f45ce4400bffafa4659e99d2225c317
Interceptorで表示しているforward, forward x 20, drop, send to Resender, send to Bulk Senderについて、enabled, disabledが切り替わるようにしました。
パケットが来ていない時は全てdisabled、クライアントからサーバへのパケットの表示時は全てenabled、サーバからクライアントへのパケットの表示時はforwardとdropをenabled、それ以外はdisabled としています。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
