### PR TITLE
Gradle の最大ヒープサイズを大きくすることで OOM を回避する

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx4096M


### PR DESCRIPTION
Gradle はデフォルトでヒープサイズが 512 MB ですが、場合によっては OOM となるため `gradle.properties` 内でもっと大きなヒープを確保するようにしました。

参考：https://docs.gradle.org/8.9/userguide/config_gradle.html#sec:configuring_jvm_memory

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
