### PR TITLE
refactor: logging methods now accept a format object

### DIFF
--- a/src/main/java/core/packetproxy/PrivateDNS.java
+++ b/src/main/java/core/packetproxy/PrivateDNS.java
@@ -260,7 +260,7 @@ public class PrivateDNS {
 								throw new UnknownHostException();
 							}
 						} else if (queryRecType == Type.HTTPS) {
-							util.packetProxyLog(String.format("[DNS Query] '%s' [HTTPS]", queryHostName));
+							util.packetProxyLog("[DNS Query] '%s' [HTTPS]", queryHostName);
 							jnamed jn;
 							if (isTargetHost(queryHostName)) {
 								Name label = Name.fromString(queryHostName + ".");
@@ -270,7 +270,7 @@ public class PrivateDNS {
 								List<HTTPSRecord.ParameterBase> params = List.of(alpn);
 								HTTPSRecord record = new HTTPSRecord(label, DClass.IN, 300, 1, svcDomain, params);
 								jn = new jnamed(record);
-								util.packetProxyLog(String.format("Force to access '%s' with HTTP3", queryHostName));
+								util.packetProxyLog("Force to access '%s' with HTTP3", queryHostName);
 							} else {
 								Record[] records = PrivateDNSClient.getHTTPSRecord(queryHostName);
 								jn = new jnamed(records);
@@ -280,14 +280,14 @@ public class PrivateDNS {
 							soc.send(sendPacket);
 							continue;
 						} else {
-							util.packetProxyLog(String.format("[DNS Query] Unsupported Query Type: '%s' [%s]",
-									queryHostName, queryRecTypeName));
+							util.packetProxyLog("[DNS Query] Unsupported Query Type: '%s' [%s]", queryHostName,
+									queryRecTypeName);
 							throw new UnsupportedOperationException();
 						}
 
 						String ip = addr.getHostAddress();
 
-						util.packetProxyLog(String.format("[DNS Query] '%s' [%s]", queryHostName, queryRecTypeName));
+						util.packetProxyLog("[DNS Query] '%s' [%s]", queryHostName, queryRecTypeName);
 						// util.packetProxyLog(String.format("[DNS Response Address] '%s'", ip));
 
 						if (isTargetHost(queryHostName)) {
@@ -308,8 +308,7 @@ public class PrivateDNS {
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 
 					} catch (UnknownHostException e) {
-						util.packetProxyLogErr(
-								String.format("[DNS Query] Unknown Host: '%s' [%s]", queryHostName, queryRecTypeName));
+						util.packetProxyLogErr("[DNS Query] Unknown Host: '%s' [%s]", queryHostName, queryRecTypeName);
 						jnamed jn = new jnamed();
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 
@@ -319,8 +318,7 @@ public class PrivateDNS {
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 
 					} catch (Exception e) {
-						util.packetProxyLogErr(
-								String.format("[DNS Query] Unknown Error: '%s' [%s]", queryHostName, queryRecTypeName));
+						util.packetProxyLogErr("[DNS Query] Unknown Error: '%s' [%s]", queryHostName, queryRecTypeName);
 						jnamed jn = new jnamed();
 						res = jn.generateReply(smsg, smsgBA, smsgBA.length, null);
 

--- a/src/main/java/core/packetproxy/PrivateDNSClient.java
+++ b/src/main/java/core/packetproxy/PrivateDNSClient.java
@@ -135,7 +135,7 @@ public class PrivateDNSClient {
             }
             hostIP = ((AAAARecord) records[0]).getAddress();
         } catch (TextParseException ex) {
-            util.packetProxyLog(String.format("'%s'", ex.getMessage()));
+            util.packetProxyLog("'%s'", ex.getMessage());
             throw new IllegalStateException(ex);
         }
         return hostIP;

--- a/src/main/java/core/packetproxy/ProxyHttp.java
+++ b/src/main/java/core/packetproxy/ProxyHttp.java
@@ -79,8 +79,7 @@ public class ProxyHttp extends Proxy {
 								String serverName = http.getServerName();
 								if (serverName.matches("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}")) {
 									serverName = Https.getCommonName(http.getServerAddr());
-									util.packetProxyLog(
-											String.format("Overwrite CN: %s --> %s", http.getServerName(), serverName));
+									util.packetProxyLog("Overwrite CN: %s --> %s", http.getServerName(), serverName);
 								}
 
 								if (SSLPassThroughs.getInstance().includes(serverName, listen_info.getPort())) {

--- a/src/main/java/core/packetproxy/ProxyQuicForward.java
+++ b/src/main/java/core/packetproxy/ProxyQuicForward.java
@@ -39,7 +39,7 @@ public class ProxyQuicForward extends Proxy {
 				PacketProxyUtility.getInstance().packetProxyLog("accept");
 
 				String serverName = this.listen_info.getServer().getIp();
-				PacketProxyUtility.getInstance().packetProxyLog(String.format("[QUIC-forward!] %s", serverName));
+				PacketProxyUtility.getInstance().packetProxyLog("[QUIC-forward!] %s", serverName);
 
 				ServerConnection serverConnection = new ServerConnection(
 						ConnectionIdPair.generateRandom(),

--- a/src/main/java/core/packetproxy/ProxyQuicTransparent.java
+++ b/src/main/java/core/packetproxy/ProxyQuicTransparent.java
@@ -42,8 +42,7 @@ public class ProxyQuicTransparent extends Proxy {
 				PacketProxyUtility.getInstance().packetProxyLog("accept");
 
 				String sniServerName = clientConnection.getSNI();
-				PacketProxyUtility.getInstance()
-						.packetProxyLog(String.format("[QUIC-forward! using SNI] %s", sniServerName));
+				PacketProxyUtility.getInstance().packetProxyLog("[QUIC-forward! using SNI] %s", sniServerName);
 
 				ServerConnection serverConnection = new ServerConnection(
 						ConnectionIdPair.generateRandom(),

--- a/src/main/java/core/packetproxy/ProxySSLTransparent.java
+++ b/src/main/java/core/packetproxy/ProxySSLTransparent.java
@@ -138,7 +138,7 @@ public class ProxySSLTransparent extends Proxy {
 			String serverName = "";
 			if (matcher.find()) {
 				serverName = matcher.group(1);
-				PacketProxyUtility.getInstance().packetProxyLog(String.format("[SSL-forward!] %s", serverName));
+				PacketProxyUtility.getInstance().packetProxyLog("[SSL-forward!] %s", serverName);
 			} else {
 				throw new Exception(I18nString.get("[Error] SNI header was not found in SSL packets."));
 			}
@@ -153,11 +153,10 @@ public class ProxySSLTransparent extends Proxy {
 			for (SNIServerName serverE : serverNames) {
 				String serverName = new String(serverE.getEncoded()); // 接続先サーバを取得
 				if (listen_info.getServer() != null) { // upstream proxy
-					PacketProxyUtility.getInstance().packetProxyLog(
-							String.format("[SSL-forward through upstream proxy! using SNI] %s", serverName));
-				} else {
 					PacketProxyUtility.getInstance()
-							.packetProxyLog(String.format("[SSL-forward! using SNI] %s", serverName));
+							.packetProxyLog("[SSL-forward through upstream proxy! using SNI] %s", serverName);
+				} else {
+					PacketProxyUtility.getInstance().packetProxyLog("[SSL-forward! using SNI] %s", serverName);
 				}
 				ByteArrayInputStream bais = new ByteArrayInputStream(buffer, 0, position);
 

--- a/src/main/java/core/packetproxy/common/BinaryBuffer.java
+++ b/src/main/java/core/packetproxy/common/BinaryBuffer.java
@@ -106,8 +106,8 @@ public class BinaryBuffer {
 		// length = 6;
 		// }
 		if (data_size < index + length) {
-			PacketProxyUtility.getInstance()
-					.packetProxyLog(String.format("[Error] Something wrong (%d < %d + %d)", data_size, index, length));
+			PacketProxyUtility.getInstance().packetProxyLog("[Error] Something wrong (%d < %d + %d)", data_size, index,
+					length);
 			return;
 		}
 		data_size_in_utf8 -= new String(buffer, index, length).length();

--- a/src/main/java/core/packetproxy/encode/EncodeMQTT.java
+++ b/src/main/java/core/packetproxy/encode/EncodeMQTT.java
@@ -165,29 +165,28 @@ public class EncodeMQTT extends Encoder {
 	 * byte[] test1 = {0x00, 0x1c};
 	 * length = mqtt.checkDelimiter(test1);
 	 * if (length != 30) {
-	 * util.packetProxyLog(String.format("Failed Test1: 30 == %d\n", length));
+	 * util.packetProxyLog("Failed Test1: 30 == %d\n", length);
 	 * return;
 	 * }
 	 * 
 	 * byte[] test2 = {0x00, (byte) 0xc6, 0x09};
 	 * length = mqtt.checkDelimiter(test2);
 	 * if (length != 1225) {
-	 * util.packetProxyLog(String.format("Failed Test2: 1222 == %d\n", length));
+	 * util.packetProxyLog("Failed Test2: 1222 == %d\n", length);
 	 * return;
 	 * }
 	 * 
 	 * byte[] test3 = {0x00, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01};
 	 * length = mqtt.checkDelimiter(test3);
 	 * if (length != 2097157) {
-	 * util.packetProxyLog(String.format("Failed Test3: 2097152 == %d\n", length));
+	 * util.packetProxyLog("Failed Test3: 2097152 == %d\n", length);
 	 * return;
 	 * }
 	 * 
 	 * byte[] test4 = {0x00, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x7F};
 	 * length = mqtt.checkDelimiter(test4);
 	 * if (length != 268435460) {
-	 * util.packetProxyLog(String.format("Failed Test4: 268435455 == %d\n",
-	 * length));
+	 * util.packetProxyLog("Failed Test4: 268435455 == %d\n", length);
 	 * return;
 	 * }
 	 * 
@@ -195,14 +194,13 @@ public class EncodeMQTT extends Encoder {
 	 * 0x01};
 	 * length = mqtt.checkDelimiter(test5);
 	 * if (length != 268435460) {
-	 * util.packetProxyLog(String.format("Failed Test5: 268435455 == %d\n",
-	 * length));
+	 * util.packetProxyLog("Failed Test5: 268435455 == %d\n", length);
 	 * return;
 	 * }
 	 * } catch (Exception e) {
 	 * e.printStackTrace();
 	 * }
-	 * util.packetProxyLog(String.format("Passed some tests."));
+	 * util.packetProxyLog("Passed some tests.");
 	 * }
 	 */
 }

--- a/src/main/java/core/packetproxy/http/Http.java
+++ b/src/main/java/core/packetproxy/http/Http.java
@@ -91,8 +91,7 @@ public class Http {
 	 * Http http = new Http(test1.getBytes());
 	 * byte[] body = http.getBody();
 	 * util.packetProxyLog(new String(body));
-	 * util.packetProxyLog(String.format("%s:%d\n", http.getProxyHost(),
-	 * http.getProxyPort()));
+	 * util.packetProxyLog("%s:%d\n", http.getProxyHost(), http.getProxyPort());
 	 * util.packetProxyLog(http.getQueryAsString());
 	 * util.packetProxyLog(http.getPath());
 	 * List<Parameter> params = Arrays.asList("a=1", "e=2", "c=3", "a=2", "aa=1",

--- a/src/main/java/core/packetproxy/model/Database.java
+++ b/src/main/java/core/packetproxy/model/Database.java
@@ -175,7 +175,7 @@ public class Database {
 				} catch (Exception e) {
 					PacketProxyUtility.getInstance().packetProxyLog(
 							"Database format may have been changed. Simply ignore this type of errors.");
-					PacketProxyUtility.getInstance().packetProxyLog(String.format("[Error] %s", query));
+					PacketProxyUtility.getInstance().packetProxyLog("[Error] %s", query);
 				}
 			}
 			conn.close();

--- a/src/main/java/core/packetproxy/model/OneShotPacket.java
+++ b/src/main/java/core/packetproxy/model/OneShotPacket.java
@@ -188,8 +188,7 @@ public class OneShotPacket implements PacketInfo, Cloneable {
 	public String getSummarizedRequest() throws Exception {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, alpn);
 		if (encoder == null) {
-			PacketProxyUtility.getInstance()
-					.packetProxyLogErr(String.format("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name));
+			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", alpn);
 		}
 		return (getDirection() == Direction.CLIENT) ? encoder.getSummarizedRequest(toPacket()) : "";
@@ -198,8 +197,7 @@ public class OneShotPacket implements PacketInfo, Cloneable {
 	public String getSummarizedResponse() throws Exception {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, alpn);
 		if (encoder == null) {
-			PacketProxyUtility.getInstance()
-					.packetProxyLogErr(String.format("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name));
+			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", alpn);
 		}
 		return (getDirection() == Direction.SERVER) ? encoder.getSummarizedResponse(toPacket()) : "";

--- a/src/main/java/core/packetproxy/model/Packet.java
+++ b/src/main/java/core/packetproxy/model/Packet.java
@@ -317,8 +317,7 @@ public class Packet implements PacketInfo {
 	public String getSummarizedRequest() throws Exception {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, null);
 		if (encoder == null) {
-			PacketProxyUtility.getInstance()
-					.packetProxyLogErr(String.format("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name));
+			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", null);
 		}
 		return (getDirection() == Direction.CLIENT) ? encoder.getSummarizedRequest(this) : "";
@@ -327,8 +326,7 @@ public class Packet implements PacketInfo {
 	public String getSummarizedResponse() throws Exception {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, null);
 		if (encoder == null) {
-			PacketProxyUtility.getInstance()
-					.packetProxyLogErr(String.format("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name));
+			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", null);
 		}
 		return (getDirection() == Direction.SERVER) ? encoder.getSummarizedResponse(this) : "";

--- a/src/main/java/core/packetproxy/model/Server.java
+++ b/src/main/java/core/packetproxy/model/Server.java
@@ -193,8 +193,8 @@ public class Server {
                 return ips;
             }
         } catch (UnknownHostException e) {
-            PacketProxyUtility.getInstance().packetProxyLogErr(
-                    String.format("Nonexistent server '%s' is specified in config [DNS resolv error]", ip));
+            PacketProxyUtility.getInstance()
+                    .packetProxyLogErr("Nonexistent server '%s' is specified in config [DNS resolv error]", ip);
             return new ArrayList<InetAddress>();
         } catch (Exception e) {
             // TODO Auto-generated catch block

--- a/src/main/java/core/packetproxy/quic/service/framegenerator/helper/ReceivedPacketNumbers.java
+++ b/src/main/java/core/packetproxy/quic/service/framegenerator/helper/ReceivedPacketNumbers.java
@@ -42,8 +42,8 @@ public class ReceivedPacketNumbers {
     public long getSmallestOfRange(long largestOfRange, long smallestValid) {
         assert (smallestValid <= largestOfRange);
         if (unreceivedPacketNumbers.contains(largestOfRange)) {
-            PacketProxyUtility.getInstance()
-                    .packetProxyLogErr(String.format("[QUIC] Error: AckRange: %d isn't in ack_range", largestOfRange));
+            PacketProxyUtility.getInstance().packetProxyLogErr("[QUIC] Error: AckRange: %d isn't in ack_range",
+                    largestOfRange);
             return 0;
         }
         return getSmallestReceived(largestOfRange, smallestValid);
@@ -52,8 +52,7 @@ public class ReceivedPacketNumbers {
     public long getSmallestOfGap(long largestOfGap, long smallestValid) {
         assert (smallestValid <= largestOfGap);
         if (!unreceivedPacketNumbers.contains(largestOfGap)) {
-            PacketProxyUtility.getInstance()
-                    .packetProxyLogErr(String.format("[QUIC] Error: AckRange: %d isn't in gap", largestOfGap));
+            PacketProxyUtility.getInstance().packetProxyLogErr("[QUIC] Error: AckRange: %d isn't in gap", largestOfGap);
             return 0;
         }
         return getSmallestUnreceived(largestOfGap, smallestValid);

--- a/src/main/java/core/packetproxy/quic/service/pnspace/PnSpace.java
+++ b/src/main/java/core/packetproxy/quic/service/pnspace/PnSpace.java
@@ -171,8 +171,8 @@ public abstract class PnSpace {
                 }
             } else if (frame instanceof ConnectionCloseFrame) {
                 ConnectionCloseFrame connCloseFrame = (ConnectionCloseFrame) frame;
-                PacketProxyUtility.getInstance().packetProxyLogErr(
-                        String.format("HTTP3 connection closed (%s)", connCloseFrame.getReasonPhraseString()));
+                PacketProxyUtility.getInstance().packetProxyLogErr("HTTP3 connection closed (%s)",
+                        connCloseFrame.getReasonPhraseString());
                 this.conn.close();
             } else if (frame instanceof NewConnectionIdFrame) {
                 /* not implemented yet */

--- a/src/main/java/core/packetproxy/util/CharSetUtility.java
+++ b/src/main/java/core/packetproxy/util/CharSetUtility.java
@@ -194,13 +194,13 @@ public class CharSetUtility {
                     return;
                 }
             }
-            PacketProxyUtility.getInstance().packetProxyLog(String.format("%s is not supported charset", charSet));
+            PacketProxyUtility.getInstance().packetProxyLog("%s is not supported charset", charSet);
         }
         if (getAvailableCharSetList().contains(charSet)) {
             this.charSet = charSet;
         } else {
             // TODO: Throw Exception
-            PacketProxyUtility.getInstance().packetProxyLog(String.format("%s is not supported charset", charSet));
+            PacketProxyUtility.getInstance().packetProxyLog("%s is not supported charset", charSet);
         }
     }
 

--- a/src/main/java/core/packetproxy/util/PacketProxyUtility.java
+++ b/src/main/java/core/packetproxy/util/PacketProxyUtility.java
@@ -51,12 +51,20 @@ public class PacketProxyUtility {
 		guiLog.append(ss);
 	}
 
+	public void packetProxyLog(String format, Object... args) {
+		packetProxyLog(String.format(format, args));
+	}
+
 	public void packetProxyLogErr(String s) {
 		LocalDateTime now = LocalDateTime.now();
 		String ns = dtf.format(now);
 		String ss = ns + "       " + s;
 		System.err.println(ss);
 		guiLog.appendErr(ss);
+	}
+
+	public void packetProxyLogErr(String format, Object... args) {
+		packetProxyLogErr(String.format(format, args));
 	}
 
 	public void packetProxyLogNewLine() {


### PR DESCRIPTION
ログ用の関数で`String.format`を渡しているものがありましたので、フォーマット用文字列を受け取れるメソッドを追加しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
