### PR TITLE
AmazonLexV2 (Bedrock) のエンコードモジュールを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@ PacketProxyは、HTTP1/HTTP2/HTTPS通信だけでなく、より低レイヤー�
   - インターセプト
   - 加工して再送
 - **HTTP/HTTPS通信だけでなく、より低レイヤーのTCP/UDP通信にも対応しています**
-  - メジャーなプロトコル（HTTP、HTTP2、HTTPS、WebSocket、FireBase、Firestore、MQTT、gRPC、Protocol Buffers、XMPP on TLS、MessagePack、CBOR）はビルトイン済み（増やす予定あり）
+  - メジャーなプロトコル（HTTP、HTTP2、HTTPS、WebSocket、FireBase、Firestore、MQTT、gRPC、Protocol Buffers、XMPP on TLS、MessagePack、CBOR、AmazonLexV2）はビルトイン済み（増やす予定あり）
   - 新しいプロトコル（例：特定ゲームの独自通信プロトコル等）への拡張が簡単
 - **脆弱性診断で利用できる便利な機能を用意しています**
   - パケットを連続して同時に送信する機能（同時複数送信）

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PacketProxy is designed for testing web applications for internal use, which hel
   - Resend (or replay) captured packets with or without manually modifying the contents
   - Show differences between any two received packets
 - **Support for protocols over TCP/UDP, not limited to HTTP/HTTPS**
-  - Built-in encoders/decoders enable users to inspect/intercept HTTP1, HTTP2, HTTPS, WebSocket, FireBase, Firestore, MQTT, gRPC, Protocol Buffers, XMPP on TLS, MessagePack, CBOR, AmazonLexV2 messages
+  - Built-in encoders/decoders enable users to inspect/intercept HTTP1, HTTP2, HTTPS, WebSocket, FireBase, Firestore, MQTT, gRPC, Protocol Buffers, XMPP on TLS, MessagePack, CBOR, and AmazonLexV2 messages
   - Easy to develop an extension to decode/encode protocols not listed above
 - **Features for application penetration tests**
   - Send multiple packets simultaneously to test race conditions or any inconsistent state due to improper synchronization/locking.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PacketProxy is designed for testing web applications for internal use, which hel
   - Resend (or replay) captured packets with or without manually modifying the contents
   - Show differences between any two received packets
 - **Support for protocols over TCP/UDP, not limited to HTTP/HTTPS**
-  - Built-in encoders/decoders enable users to inspect/intercept HTTP1, HTTP2, HTTPS, WebSocket, FireBase, Firestore, MQTT, gRPC, Protocol Buffers, XMPP on TLS, MessagePack, and CBOR messages
+  - Built-in encoders/decoders enable users to inspect/intercept HTTP1, HTTP2, HTTPS, WebSocket, FireBase, Firestore, MQTT, gRPC, Protocol Buffers, XMPP on TLS, MessagePack, CBOR, AmazonLexV2 messages
   - Easy to develop an extension to decode/encode protocols not listed above
 - **Features for application penetration tests**
   - Send multiple packets simultaneously to test race conditions or any inconsistent state due to improper synchronization/locking.

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
   implementation 'org.bouncycastle:bcpkix-jdk15on:1.64'
   implementation 'commons-net:commons-net:3.6'
   implementation 'org.nanohttpd:nanohttpd:2.3.1'
-  implementation 'com.google.code.gson:gson:2.8.6'
+  implementation 'com.google.code.gson:gson:2.13.1'
   implementation 'org.apache.commons:commons-math3:3.0'
   implementation 'org.jfree:jfreechart:1.5.3'
   implementation 'org.ejml:ejml-all:0.41'

--- a/src/main/java/core/packetproxy/common/AmazonLexV2.java
+++ b/src/main/java/core/packetproxy/common/AmazonLexV2.java
@@ -1,0 +1,164 @@
+package packetproxy.common;
+
+import java.util.zip.CRC32;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.Objects;
+
+// ref: https://docs.aws.amazon.com/lexv2/latest/dg/event-stream-encoding.html
+
+public record AmazonLexV2(
+    Message[] messages
+) {
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        AmazonLexV2 that = (AmazonLexV2) obj;
+        return Arrays.equals(messages, that.messages);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(messages);
+    }
+
+    public record Message(
+        MessageHeader[] headers,
+        byte[] payload
+    ) {
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            Message message = (Message) obj;
+            return Arrays.equals(headers, message.headers) && Arrays.equals(payload, message.payload);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(Arrays.hashCode(headers), Arrays.hashCode(payload));
+        }
+    }
+
+    public record MessageHeader(
+        String headerName,
+        byte headerValueType,
+        String valueString
+    ) {}
+
+    public static AmazonLexV2 fromBytes(byte[] body) throws Exception {
+        if (body == null || body.length == 0) {
+            throw new IllegalArgumentException("Body cannot be null or empty");
+        }
+        var messages = new java.util.ArrayList<Message>();
+        int pos = 0;
+        while (pos < body.length) {
+            int totalByteLength = ((body[pos++] & 0xFF) << 24) |
+                                  ((body[pos++] & 0xFF) << 16) |
+                                  ((body[pos++] & 0xFF) << 8) |
+                                  (body[pos++] & 0xFF);
+
+            int headersByteLength = ((body[pos++] & 0xFF) << 24) |
+                                    ((body[pos++] & 0xFF) << 16) |
+                                    ((body[pos++] & 0xFF) << 8) |
+                                    (body[pos++] & 0xFF);
+
+            int preludeCRC = ((body[pos++] & 0xFF) << 24) |
+                             ((body[pos++] & 0xFF) << 16) |
+                             ((body[pos++] & 0xFF) << 8) |
+                             (body[pos++] & 0xFF);
+
+            java.util.List<MessageHeader> headers = new java.util.ArrayList<>();
+            
+            int headerAbsPos = pos + headersByteLength;
+            while (pos < headerAbsPos) {
+                byte headerNameByteLength = body[pos++];
+                String headerName = new String(body, pos, headerNameByteLength);
+                pos += headerNameByteLength;
+
+                byte headerValueType = body[pos++];
+                short valueStringByteLength = (short)(((body[pos++] & 0xFF) << 8) | (body[pos++] & 0xFF));
+                String valueString = new String(body, pos, valueStringByteLength);
+                pos += valueStringByteLength;
+
+                headers.add(new MessageHeader(headerName, headerValueType, valueString));
+            }
+
+            byte[] payload = new byte[totalByteLength - headersByteLength - 16];
+            System.arraycopy(body, pos, payload, 0, payload.length);
+            pos += payload.length;
+
+            int messageCRC = ((body[pos++] & 0xFF) << 24) |
+                             ((body[pos++] & 0xFF) << 16) |
+                             ((body[pos++] & 0xFF) << 8) |
+                             (body[pos++] & 0xFF);  
+            if (pos > body.length) {
+                throw new Exception("Invalid message length: " + totalByteLength + ", pos: "
+                                    + pos + ", body length: " + body.length);
+            }
+            messages.add(new Message(headers.toArray(new MessageHeader[0]), payload));
+        }
+        return new AmazonLexV2(messages.toArray(new Message[0]));
+    }
+    public static byte[] toBytes(AmazonLexV2 lex) throws Exception {
+        if (lex == null || lex.messages == null || lex.messages.length == 0) {
+            throw new IllegalArgumentException("Lex messages cannot be null or empty");
+        }
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        for (Message message : lex.messages) {
+            int totalByteLength = 16 + message.payload.length;
+            int headersByteLength = 0;
+            for (MessageHeader header : message.headers) {
+                int headerByteLength = 1 + header.headerName.length() + 1 + 2 + header.valueString.length();
+                headersByteLength += headerByteLength;
+                totalByteLength += headerByteLength;
+            }
+            
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            baos.write((totalByteLength >> 24) & 0xFF);
+            baos.write((totalByteLength >> 16) & 0xFF);
+            baos.write((totalByteLength >> 8) & 0xFF);
+            baos.write(totalByteLength & 0xFF);
+
+            baos.write((headersByteLength >> 24) & 0xFF);
+            baos.write((headersByteLength >> 16) & 0xFF);
+            baos.write((headersByteLength >> 8) & 0xFF);
+            baos.write(headersByteLength & 0xFF);
+
+            CRC32 crc32 = new CRC32();
+            byte[] preludeBytes = baos.toByteArray();
+            crc32.update(preludeBytes);
+            int preludeCRC = (int) crc32.getValue();
+            baos.write((preludeCRC >> 24) & 0xFF);
+            baos.write((preludeCRC >> 16) & 0xFF);
+            baos.write((preludeCRC >> 8) & 0xFF);
+            baos.write(preludeCRC & 0xFF);
+
+            for (MessageHeader header : message.headers) {
+                baos.write(header.headerName.length());
+                baos.write(header.headerName.getBytes());
+                baos.write(header.headerValueType);
+                byte[] valueBytes = header.valueString.getBytes("UTF-8");
+                baos.write((valueBytes.length >> 8) & 0xFF);
+                baos.write(valueBytes.length & 0xFF);
+                baos.write(valueBytes);
+            }
+
+            baos.write(message.payload);
+            
+            CRC32 messageCRC32 = new CRC32();
+            byte[] messageBytes = baos.toByteArray();
+            messageCRC32.update(messageBytes);
+            int messageCRC = (int) messageCRC32.getValue();
+            baos.write((messageCRC >> 24) & 0xFF);
+            baos.write((messageCRC >> 16) & 0xFF);
+            baos.write((messageCRC >> 8) & 0xFF);
+            baos.write(messageCRC & 0xFF);
+            
+            outputStream.write(baos.toByteArray());
+        }
+        return outputStream.toByteArray();
+    }
+
+}

--- a/src/main/java/core/packetproxy/common/AmazonLexV2.java
+++ b/src/main/java/core/packetproxy/common/AmazonLexV2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package packetproxy.common;
 
 import java.util.zip.CRC32;

--- a/src/main/java/core/packetproxy/common/AmazonLexV2.java
+++ b/src/main/java/core/packetproxy/common/AmazonLexV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 DeNA Co., Ltd.
+ * Copyright 2025 DeNA Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
+++ b/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.encode;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.ArrayList;
+import java.util.zip.CRC32;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import packetproxy.http.Http;
+import packetproxy.util.PacketProxyUtility;
+import packetproxy.common.AmazonLexV2;
+
+public class EncodeAmazonLexV2 extends EncodeHTTPBase
+{
+	public EncodeAmazonLexV2(String ALPN) throws Exception {
+		super(ALPN);
+	}
+
+	@Override
+	public String getName() {
+		return "Amazon Lex V2 (Event Streaming)";
+	}
+
+	@Override
+	protected Http decodeClientRequestHttp(Http inputHttp) throws Exception {
+		return inputHttp;
+	}
+
+	@Override
+	protected Http encodeClientRequestHttp(Http inputHttp) throws Exception {
+		return inputHttp;
+	}
+
+	@Override
+	protected Http decodeServerResponseHttp(Http inputHttp) throws Exception {
+		PacketProxyUtility util = PacketProxyUtility.getInstance();
+		var contentType = inputHttp.getFirstHeader("Content-Type");
+		if (!contentType.startsWith("application/vnd.amazon.eventstream")) {
+			util.packetProxyLog("[EncodeAmazonLexV2] Content-type is not specified or other content-type detected.");
+			return inputHttp;
+		}
+		byte[] body = inputHttp.getBody();
+		final int bodyLength = body.length;
+		
+		AmazonLexV2 event = AmazonLexV2.fromBytes(body);
+
+		// Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		Gson gson = new GsonBuilder().create();
+		String json = gson.toJson(event);
+
+		inputHttp.setBody(json.getBytes("UTF-8"));
+		return inputHttp;
+	}
+
+	@Override
+	protected Http encodeServerResponseHttp(Http inputHttp) throws Exception {
+		PacketProxyUtility util = PacketProxyUtility.getInstance();
+		var contentType = inputHttp.getFirstHeader("Content-Type");
+		if (!contentType.startsWith("application/vnd.amazon.eventstream")) {
+			util.packetProxyLog("[EncodeAmazonLexV2] Content-type is not specified or other content-type detected." + contentType);
+			return inputHttp;
+		}
+
+		byte[] body = inputHttp.getBody();
+		if (body.length == 0) {
+			util.packetProxyLog("[EncodeAmazonLexV2] Warning: Empty body detected, skipping encoding.");
+			return inputHttp;
+		}
+
+		Gson gson = new GsonBuilder().create();
+
+		AmazonLexV2 lex = gson.fromJson(new String(body, "UTF-8"), AmazonLexV2.class);
+		
+		if (lex == null) {
+			util.packetProxyLog("[EncodeAmazonLexV2] Warning: Invalid Amazon Lex V2 Event Stream detected, skipping encoding.");
+			return inputHttp;
+		}
+
+		byte[] encoded = AmazonLexV2.toBytes(lex);
+		
+		inputHttp.setBody(encoded);
+
+		return inputHttp;
+	}
+}

--- a/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
+++ b/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
@@ -37,7 +37,7 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase
 
 	@Override
 	public String getName() {
-		return "Amazon Lex V2 (Event Streaming)";
+		return "Amazon LexV2 (Event Streaming)";
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase
 		PacketProxyUtility util = PacketProxyUtility.getInstance();
 		var contentType = inputHttp.getFirstHeader("Content-Type");
 		if (!contentType.startsWith("application/vnd.amazon.eventstream")) {
-			util.packetProxyLog("[EncodeAmazonLexV2] Content-type is not specified or other content-type detected.");
+			util.packetProxyLog("[EncodeAmazonLexV2] decodeServerResponseHttp: Content-type is not specified or other content-type detected: " + contentType);
 			return inputHttp;
 		}
 		byte[] body = inputHttp.getBody();
@@ -63,7 +63,6 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase
 		
 		AmazonLexV2 event = AmazonLexV2.fromBytes(body);
 
-		// Gson gson = new GsonBuilder().setPrettyPrinting().create();
 		Gson gson = new GsonBuilder().create();
 		String json = gson.toJson(event);
 
@@ -76,7 +75,7 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase
 		PacketProxyUtility util = PacketProxyUtility.getInstance();
 		var contentType = inputHttp.getFirstHeader("Content-Type");
 		if (!contentType.startsWith("application/vnd.amazon.eventstream")) {
-			util.packetProxyLog("[EncodeAmazonLexV2] Content-type is not specified or other content-type detected." + contentType);
+			util.packetProxyLog("[EncodeAmazonLexV2] encodeServerResponseHttp: Content-type is not specified or other content-type detected: " + contentType);
 			return inputHttp;
 		}
 
@@ -89,7 +88,7 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase
 		Gson gson = new GsonBuilder().create();
 
 		AmazonLexV2 lex = gson.fromJson(new String(body, "UTF-8"), AmazonLexV2.class);
-		
+
 		if (lex == null) {
 			util.packetProxyLog("[EncodeAmazonLexV2] Warning: Invalid Amazon Lex V2 Event Stream detected, skipping encoding.");
 			return inputHttp;

--- a/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
+++ b/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 DeNA Co., Ltd.
+ * Copyright 2025 DeNA Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/packetproxy/common/AmazonLexV2Test.java
+++ b/src/test/java/packetproxy/common/AmazonLexV2Test.java
@@ -21,36 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AmazonLexV2Test {
-
-    @Test
-    public void testAmazonLexV2EqualsTest() throws Exception {
-        AmazonLexV2.MessageHeader[] headers = {
-            new AmazonLexV2.MessageHeader(":content-type", (byte)7, "application/json"),
-            new AmazonLexV2.MessageHeader(":event-type", (byte)7, "text")
-        };
-        
-        byte[] payload = "Hello World".getBytes("UTF-8");
-        
-        AmazonLexV2.Message message = new AmazonLexV2.Message(headers, payload);
-        AmazonLexV2.Message[] messages = {message};
-        
-        AmazonLexV2 original = new AmazonLexV2(messages);
-
-        AmazonLexV2.MessageHeader[] headers2 = {
-            new AmazonLexV2.MessageHeader(":content-type", (byte)7, "application/json"),
-            new AmazonLexV2.MessageHeader(":event-type", (byte)7, "text")
-        };
-        
-        byte[] payload2 = "Hello World".getBytes("UTF-8");
-        
-        AmazonLexV2.Message message2 = new AmazonLexV2.Message(headers2, payload2);
-        AmazonLexV2.Message[] messages2 = {message2};
-        
-        AmazonLexV2 original2 = new AmazonLexV2(messages2);
-
-        assert(original.equals(original2));
-    }
-
     @Test
     public void testToBytesAndFromBytes() throws Exception {
         AmazonLexV2.MessageHeader[] headers = {

--- a/src/test/java/packetproxy/common/AmazonLexV2Test.java
+++ b/src/test/java/packetproxy/common/AmazonLexV2Test.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AmazonLexV2Test {
+
+    @Test
+    public void testAmazonLexV2EqualsTest() throws Exception {
+        AmazonLexV2.MessageHeader[] headers = {
+            new AmazonLexV2.MessageHeader(":content-type", (byte)7, "application/json"),
+            new AmazonLexV2.MessageHeader(":event-type", (byte)7, "text")
+        };
+        
+        byte[] payload = "Hello World".getBytes("UTF-8");
+        
+        AmazonLexV2.Message message = new AmazonLexV2.Message(headers, payload);
+        AmazonLexV2.Message[] messages = {message};
+        
+        AmazonLexV2 original = new AmazonLexV2(messages);
+
+        AmazonLexV2.MessageHeader[] headers2 = {
+            new AmazonLexV2.MessageHeader(":content-type", (byte)7, "application/json"),
+            new AmazonLexV2.MessageHeader(":event-type", (byte)7, "text")
+        };
+        
+        byte[] payload2 = "Hello World".getBytes("UTF-8");
+        
+        AmazonLexV2.Message message2 = new AmazonLexV2.Message(headers2, payload2);
+        AmazonLexV2.Message[] messages2 = {message2};
+        
+        AmazonLexV2 original2 = new AmazonLexV2(messages2);
+
+        assert(original.equals(original2));
+    }
+
+    @Test
+    public void testToBytesAndFromBytes() throws Exception {
+        AmazonLexV2.MessageHeader[] headers = {
+            new AmazonLexV2.MessageHeader(":content-type", (byte)7, "application/json"),
+            new AmazonLexV2.MessageHeader(":event-type", (byte)7, "text")
+        };
+        
+        byte[] payload = "Hello World".getBytes("UTF-8");
+        
+        AmazonLexV2.Message message = new AmazonLexV2.Message(headers, payload);
+        AmazonLexV2.Message[] messages = {message};
+        
+        AmazonLexV2 original = new AmazonLexV2(messages);
+        
+        byte[] bytes = AmazonLexV2.toBytes(original);
+        AmazonLexV2 decoded = AmazonLexV2.fromBytes(bytes);
+        
+        assert(original.equals(decoded));
+    }
+
+    @Test
+    public void testToBytesAndFromBytesMultipleMessages() throws Exception {
+        AmazonLexV2.MessageHeader[] headers1 = {
+            new AmazonLexV2.MessageHeader(":content-type", (byte)7, "application/json")
+        };
+        AmazonLexV2.MessageHeader[] headers2 = {
+            new AmazonLexV2.MessageHeader(":event-type", (byte)7, "audio")
+        };
+        
+        byte[] payload1 = "First message".getBytes("UTF-8");
+        byte[] payload2 = "Second message".getBytes("UTF-8");
+        
+        AmazonLexV2.Message message1 = new AmazonLexV2.Message(headers1, payload1);
+        AmazonLexV2.Message message2 = new AmazonLexV2.Message(headers2, payload2);
+        AmazonLexV2.Message[] messages = {message1, message2};
+        
+        AmazonLexV2 original = new AmazonLexV2(messages);
+        
+        byte[] bytes = AmazonLexV2.toBytes(original);
+        AmazonLexV2 decoded = AmazonLexV2.fromBytes(bytes);
+        
+        assert(original.equals(decoded));
+    }
+
+    @Test
+    public void testEmptyPayload() throws Exception {
+        AmazonLexV2.MessageHeader[] headers = {
+            new AmazonLexV2.MessageHeader(":event-type", (byte)7, "heartbeat")
+        };
+        
+        byte[] payload = new byte[0];
+        
+        AmazonLexV2.Message message = new AmazonLexV2.Message(headers, payload);
+        AmazonLexV2.Message[] messages = {message};
+        
+        AmazonLexV2 original = new AmazonLexV2(messages);
+        
+        byte[] bytes = AmazonLexV2.toBytes(original);
+        AmazonLexV2 decoded = AmazonLexV2.fromBytes(bytes);
+        
+        assert(original.equals(decoded));
+    }
+}

--- a/src/test/java/packetproxy/common/AmazonLexV2Test.java
+++ b/src/test/java/packetproxy/common/AmazonLexV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 DeNA Co., Ltd.
+ * Copyright 2025 DeNA Co., Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## 概要
Bedrock 等の Streaming に利用されている、AmazonLexV2 のエンコードモジュールを実装しました。

https://docs.aws.amazon.com/lexv2/latest/dg/event-stream-encoding.html に基づいて、AmazonLexV2 のサーバーレスポンスのパケットの解析・表示を行います。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
