### PR TITLE
refactor: extract logging functionalities from the util class

### DIFF
--- a/src/main/java/core/packetproxy/ListenPortManager.java
+++ b/src/main/java/core/packetproxy/ListenPortManager.java
@@ -16,6 +16,8 @@
 package packetproxy;
 
 import static packetproxy.model.PropertyChangeEventType.LISTEN_PORTS;
+import static packetproxy.util.Logging.err;
+import static packetproxy.util.Logging.log;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -26,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import packetproxy.model.ListenPort;
 import packetproxy.model.ListenPorts;
-import packetproxy.util.PacketProxyUtility;
 
 public class ListenPortManager implements PropertyChangeListener {
 
@@ -97,18 +98,17 @@ public class ListenPortManager implements PropertyChangeListener {
 					listen.close();
 					Listen new_listen = new Listen(listen_port);
 					listen_map.put(listen_port.getProtoPort(), new_listen);
-					PacketProxyUtility.getInstance().packetProxyLog("## restart:" + listen_port.getProtoPort());
+					log("## restart: %s", listen_port.getProtoPort());
 				}
 			} else {
 
-				PacketProxyUtility.getInstance().packetProxyLog("## start:" + listen_port.getProtoPort());
+				log("## start: %s", listen_port.getProtoPort());
 				Listen new_listen = new Listen(listen_port);
 				listen_map.put(listen_port.getProtoPort(), new_listen);
 			}
 		} catch (BindException e) {
 
-			PacketProxyUtility.getInstance()
-					.packetProxyLogErr("cannot listen port. (permission issue or already listened)");
+			err("cannot listen port. (permission issue or already listened)");
 			listen_port.setDisabled();
 			listenPorts.update(listen_port);
 		}

--- a/src/main/java/core/packetproxy/OpenVPN.java
+++ b/src/main/java/core/packetproxy/OpenVPN.java
@@ -15,6 +15,9 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.err;
+import static packetproxy.util.Logging.log;
+
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
@@ -46,7 +49,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import packetproxy.model.OpenVPNForwardPort;
 import packetproxy.model.OpenVPNForwardPorts;
-import packetproxy.util.PacketProxyUtility;
 
 public class OpenVPN {
 
@@ -98,10 +100,10 @@ public class OpenVPN {
 
 			if (pulling) {
 
-				PacketProxyUtility.getInstance().packetProxyLog("already pulling image...");
+				log("already pulling image...");
 				return false;
 			}
-			PacketProxyUtility.getInstance().packetProxyLog("docker image not found. start pulling...");
+			log("docker image not found. start pulling...");
 			pulling = true;
 			client.pullImageCmd(imageName).exec(new PullImageResultCallback());
 			return false;
@@ -142,7 +144,7 @@ public class OpenVPN {
 		if (inspect.getState().getRunning()) {
 
 			// running
-			PacketProxyUtility.getInstance().packetProxyLog("OpenVPN Server is already running");
+			log("OpenVPN Server is already running");
 			return;
 		}
 
@@ -152,10 +154,10 @@ public class OpenVPN {
 			client.startContainerCmd(containerName).exec();
 		} catch (NotFoundException e) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr(e.toString());
+			err(e.toString());
 		} catch (NotModifiedException e) {
 
-			PacketProxyUtility.getInstance().packetProxyLog(e.toString());
+			log(e.toString());
 		} catch (Exception e) {
 
 			e.printStackTrace();
@@ -169,7 +171,7 @@ public class OpenVPN {
 			remove.exec();
 		} catch (NotFoundException e) {
 
-			PacketProxyUtility.getInstance().packetProxyLog(e.toString());
+			log(e.toString());
 		}
 	}
 
@@ -228,7 +230,7 @@ public class OpenVPN {
 			 * start(now doing)
 			 * - after patching, the server should be restarted to reflect the config
 			 */
-			PacketProxyUtility.getInstance().packetProxyLog("OpenVPN Server is restarting...");
+			log("OpenVPN Server is restarting...");
 			// kill the process and restart openvpn
 			commands = new String[]{"/bin/sh", "-c", "kill $(pgrep openvpn)"};
 			execCommand(client, commands);

--- a/src/main/java/core/packetproxy/PrivateDNSClient.java
+++ b/src/main/java/core/packetproxy/PrivateDNSClient.java
@@ -16,6 +16,8 @@
 
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
@@ -110,7 +112,7 @@ public class PrivateDNSClient {
 			if (serverName.equals(resolution.getHostName())) {
 
 				String ip = resolution.getIp();
-				util.packetProxyLog("[Hostname Resolution]: " + serverName + " -> " + ip);
+				log("[Hostname Resolution]: %s -> %s", serverName, ip);
 				return InetAddress.getByName(ip);
 			}
 		}
@@ -143,7 +145,7 @@ public class PrivateDNSClient {
 			hostIP = ((AAAARecord) records[0]).getAddress();
 		} catch (TextParseException ex) {
 
-			util.packetProxyLog("'%s'", ex.getMessage());
+			log("'%s'", ex.getMessage());
 			throw new IllegalStateException(ex);
 		}
 		return hostIP;

--- a/src/main/java/core/packetproxy/ProxyFactory.java
+++ b/src/main/java/core/packetproxy/ProxyFactory.java
@@ -15,10 +15,11 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import java.net.ServerSocket;
 import packetproxy.common.I18nString;
 import packetproxy.model.ListenPort;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyFactory {
 
@@ -31,19 +32,19 @@ public class ProxyFactory {
 
 		} else if (listen_info.getType() == ListenPort.TYPE.SSL_FORWARDER) {
 
-			PacketProxyUtility.getInstance().packetProxyLog("type is SSL_FORWARDER");
+			log("type is SSL_FORWARDER");
 			ServerSocket listen_socket = new ServerSocket(listen_info.getPort());
 			proxy = new ProxySSLForward(listen_socket, listen_info);
 
 		} else if (listen_info.getType() == ListenPort.TYPE.HTTP_TRANSPARENT_PROXY) {
 
-			PacketProxyUtility.getInstance().packetProxyLog("type is HTTP_TRANSPARENT_PROXY");
+			log("type is HTTP_TRANSPARENT_PROXY");
 			ServerSocket listen_socket = new ServerSocket(listen_info.getPort());
 			proxy = new ProxyHttpTransparent(listen_socket, listen_info);
 
 		} else if (listen_info.getType() == ListenPort.TYPE.SSL_TRANSPARENT_PROXY) {
 
-			PacketProxyUtility.getInstance().packetProxyLog("type is SSL_TRANSPARENT_PROXY");
+			log("type is SSL_TRANSPARENT_PROXY");
 			ServerSocket listen_socket = new ServerSocket(listen_info.getPort());
 			proxy = new ProxySSLTransparent(listen_socket, listen_info);
 
@@ -61,7 +62,7 @@ public class ProxyFactory {
 
 		} else if (listen_info.getType() == ListenPort.TYPE.XMPP_SSL_FORWARDER) {
 
-			PacketProxyUtility.getInstance().packetProxyLog("type is XMPP_SSL_FORWARDER");
+			log("type is XMPP_SSL_FORWARDER");
 			ServerSocket listen_socket = new ServerSocket(listen_info.getPort());
 			listen_socket.setReuseAddress(true);
 			proxy = new ProxyXmppSSLForward(listen_socket, listen_info);
@@ -72,8 +73,7 @@ public class ProxyFactory {
 			listen_socket.setReuseAddress(true);
 			proxy = new ProxyForward(listen_socket, listen_info);
 		}
-		PacketProxyUtility.getInstance()
-				.packetProxyLog(I18nString.get("Start listening port %d.", listen_info.getPort()));
+		log(I18nString.get("Start listening port %d.", listen_info.getPort()));
 		return proxy;
 	}
 }

--- a/src/main/java/core/packetproxy/ProxyForward.java
+++ b/src/main/java/core/packetproxy/ProxyForward.java
@@ -15,13 +15,14 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import java.net.ServerSocket;
 import java.net.Socket;
 import packetproxy.common.Endpoint;
 import packetproxy.common.EndpointFactory;
 import packetproxy.common.SocketEndpoint;
 import packetproxy.model.ListenPort;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyForward extends Proxy {
 
@@ -40,7 +41,7 @@ public class ProxyForward extends Proxy {
 			try {
 
 				Socket client = listen_socket.accept();
-				PacketProxyUtility.getInstance().packetProxyLog("accept");
+				log("accept");
 
 				Endpoint server_e = EndpointFactory.createFromServer(listen_info.getServer());
 				createConnection(new SocketEndpoint(client), server_e);

--- a/src/main/java/core/packetproxy/ProxyHttp.java
+++ b/src/main/java/core/packetproxy/ProxyHttp.java
@@ -15,6 +15,8 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
@@ -30,7 +32,6 @@ import packetproxy.model.ListenPort;
 import packetproxy.model.SSLPassThroughs;
 import packetproxy.model.Server;
 import packetproxy.model.Servers;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyHttp extends Proxy {
 
@@ -49,10 +50,9 @@ public class ProxyHttp extends Proxy {
 
 			try {
 
-				PacketProxyUtility util = PacketProxyUtility.getInstance();
 				final Socket client = listen_socket.accept();
 				clients.add(client);
-				util.packetProxyLog("accept");
+				log("accept");
 
 				final Simplex client_loopback = new Simplex(client.getInputStream(), client.getOutputStream());
 
@@ -83,7 +83,7 @@ public class ProxyHttp extends Proxy {
 								if (serverName.matches("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}")) {
 
 									serverName = Https.getCommonName(http.getServerAddr());
-									util.packetProxyLog("Overwrite CN: %s --> %s", http.getServerName(), serverName);
+									log("Overwrite CN: %s --> %s", http.getServerName(), serverName);
 								}
 
 								if (SSLPassThroughs.getInstance().includes(serverName, listen_info.getPort())) {

--- a/src/main/java/core/packetproxy/ProxyHttpTransparent.java
+++ b/src/main/java/core/packetproxy/ProxyHttpTransparent.java
@@ -15,6 +15,9 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.err;
+import static packetproxy.util.Logging.log;
+
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import java.io.ByteArrayInputStream;
@@ -30,7 +33,6 @@ import packetproxy.http.Http;
 import packetproxy.model.ListenPort;
 import packetproxy.model.Server;
 import packetproxy.model.Servers;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyHttpTransparent extends Proxy {
 
@@ -53,7 +55,7 @@ public class ProxyHttpTransparent extends Proxy {
 			try {
 
 				Socket client = listen_socket.accept();
-				PacketProxyUtility.getInstance().packetProxyLog("[ProxyHttpTransparent]: accept");
+				log("[ProxyHttpTransparent]: accept");
 				createHttpTransparentProxy(client);
 			} catch (Exception e) {
 
@@ -123,14 +125,14 @@ public class ProxyHttpTransparent extends Proxy {
 		}
 		if (hostPort == null) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr(new String(input_data));
-			PacketProxyUtility.getInstance().packetProxyLogErr("bout length == " + bout.size());
+			err(new String(input_data));
+			err("bout length == %d", bout.size());
 			if (bout.size() == 0) {
 
-				PacketProxyUtility.getInstance().packetProxyLogErr("empty request!!");
+				err("empty request!!");
 				return;
 			}
-			PacketProxyUtility.getInstance().packetProxyLogErr("HTTP Host field is not found.");
+			err("HTTP Host field is not found.");
 			return;
 		}
 
@@ -154,8 +156,7 @@ public class ProxyHttpTransparent extends Proxy {
 		} catch (ConnectException e) {
 
 			InetSocketAddress addr = hostPort.getInetSocketAddress();
-			PacketProxyUtility.getInstance()
-					.packetProxyLog("Connection Refused: " + addr.getHostName() + ":" + addr.getPort());
+			log("Connection Refused: %s:%d", addr.getHostName(), addr.getPort());
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/core/packetproxy/ProxyQuicForward.java
+++ b/src/main/java/core/packetproxy/ProxyQuicForward.java
@@ -15,12 +15,13 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import packetproxy.model.ListenPort;
 import packetproxy.quic.service.connection.ClientConnection;
 import packetproxy.quic.service.connection.ClientConnections;
 import packetproxy.quic.service.connection.ServerConnection;
 import packetproxy.quic.value.ConnectionIdPair;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyQuicForward extends Proxy {
 
@@ -39,10 +40,10 @@ public class ProxyQuicForward extends Proxy {
 			while (true) {
 
 				ClientConnection clientConnection = this.clientConnections.accept();
-				PacketProxyUtility.getInstance().packetProxyLog("accept");
+				log("accept");
 
 				String serverName = this.listen_info.getServer().getIp();
-				PacketProxyUtility.getInstance().packetProxyLog("[QUIC-forward!] %s", serverName);
+				log("[QUIC-forward!] %s", serverName);
 
 				ServerConnection serverConnection = new ServerConnection(ConnectionIdPair.generateRandom(), serverName,
 						this.listen_info.getPort());

--- a/src/main/java/core/packetproxy/ProxyQuicTransparent.java
+++ b/src/main/java/core/packetproxy/ProxyQuicTransparent.java
@@ -16,6 +16,8 @@
 
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import packetproxy.model.ListenPort;
 import packetproxy.model.Server;
 import packetproxy.model.Servers;
@@ -23,7 +25,6 @@ import packetproxy.quic.service.connection.ClientConnection;
 import packetproxy.quic.service.connection.ClientConnections;
 import packetproxy.quic.service.connection.ServerConnection;
 import packetproxy.quic.value.ConnectionIdPair;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyQuicTransparent extends Proxy {
 
@@ -42,10 +43,10 @@ public class ProxyQuicTransparent extends Proxy {
 			while (true) {
 
 				ClientConnection clientConnection = this.clientConnections.accept();
-				PacketProxyUtility.getInstance().packetProxyLog("accept");
+				log("accept");
 
 				String sniServerName = clientConnection.getSNI();
-				PacketProxyUtility.getInstance().packetProxyLog("[QUIC-forward! using SNI] %s", sniServerName);
+				log("[QUIC-forward! using SNI] %s", sniServerName);
 
 				ServerConnection serverConnection = new ServerConnection(ConnectionIdPair.generateRandom(),
 						sniServerName, this.listen_info.getPort());

--- a/src/main/java/core/packetproxy/ProxySSLForward.java
+++ b/src/main/java/core/packetproxy/ProxySSLForward.java
@@ -15,6 +15,8 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -28,7 +30,6 @@ import packetproxy.encode.Encoder;
 import packetproxy.model.ListenPort;
 import packetproxy.model.SSLPassThroughs;
 import packetproxy.model.Server;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxySSLForward extends Proxy {
 
@@ -49,7 +50,7 @@ public class ProxySSLForward extends Proxy {
 
 				Socket client = listen_socket.accept();
 				clients.add(client);
-				PacketProxyUtility.getInstance().packetProxyLog("[SSLForward] accept");
+				log("[SSLForward] accept");
 				checkSSLForward(client);
 			} catch (Exception e) {
 

--- a/src/main/java/core/packetproxy/ProxySSLTransparent.java
+++ b/src/main/java/core/packetproxy/ProxySSLTransparent.java
@@ -15,6 +15,8 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import java.io.ByteArrayInputStream;
@@ -40,7 +42,6 @@ import packetproxy.model.ListenPort;
 import packetproxy.model.SSLPassThroughs;
 import packetproxy.model.Server;
 import packetproxy.model.Servers;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxySSLTransparent extends Proxy {
 
@@ -65,7 +66,7 @@ public class ProxySSLTransparent extends Proxy {
 
 				Socket client = listen_socket.accept();
 				clients.add(client);
-				PacketProxyUtility.getInstance().packetProxyLog("[ProxySSLTransparent]: accept");
+				log("[ProxySSLTransparent]: accept");
 				checkTransparentSSLProxy(client, listen_socket.getLocalPort());
 			} catch (Exception e) {
 
@@ -148,7 +149,7 @@ public class ProxySSLTransparent extends Proxy {
 			if (matcher.find()) {
 
 				serverName = matcher.group(1);
-				PacketProxyUtility.getInstance().packetProxyLog("[SSL-forward!] %s", serverName);
+				log("[SSL-forward!] %s", serverName);
 			} else {
 
 				throw new Exception(I18nString.get("[Error] SNI header was not found in SSL packets."));
@@ -167,11 +168,10 @@ public class ProxySSLTransparent extends Proxy {
 				String serverName = new String(serverE.getEncoded()); // 接続先サーバを取得
 				if (listen_info.getServer() != null) { // upstream proxy
 
-					PacketProxyUtility.getInstance()
-							.packetProxyLog("[SSL-forward through upstream proxy! using SNI] %s", serverName);
+					log("[SSL-forward through upstream proxy! using SNI] %s", serverName);
 				} else {
 
-					PacketProxyUtility.getInstance().packetProxyLog("[SSL-forward! using SNI] %s", serverName);
+					log("[SSL-forward! using SNI] %s", serverName);
 				}
 				ByteArrayInputStream bais = new ByteArrayInputStream(buffer, 0, position);
 
@@ -193,7 +193,7 @@ public class ProxySSLTransparent extends Proxy {
 
 					/* listenポート番号と同じポート番号へアクセスできないので443番にフォールバックする */
 					serverAddr = new InetSocketAddress(PrivateDNSClient.getByName(serverName), 443);
-					PacketProxyUtility.getInstance().packetProxyLog("[Fallback port] " + proxyPort + " -> 443");
+					log("[Fallback port] %d -> 443", proxyPort);
 				}
 
 				if (SSLPassThroughs.getInstance().includes(serverName, listen_info.getPort())) {

--- a/src/main/java/core/packetproxy/ProxyUDPForward.java
+++ b/src/main/java/core/packetproxy/ProxyUDPForward.java
@@ -15,12 +15,13 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.log;
+
 import java.net.InetSocketAddress;
 import packetproxy.common.Endpoint;
 import packetproxy.common.UDPServerSocket;
 import packetproxy.common.UDPSocketEndpoint;
 import packetproxy.model.ListenPort;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyUDPForward extends Proxy {
 
@@ -39,7 +40,7 @@ public class ProxyUDPForward extends Proxy {
 			while (true) {
 
 				Endpoint client_endpoint = listen_socket.accept();
-				PacketProxyUtility.getInstance().packetProxyLog("accept");
+				log("accept");
 
 				InetSocketAddress serverAddr = listen_info.getServer().getAddress();
 				UDPSocketEndpoint server_endpoint = new UDPSocketEndpoint(serverAddr);

--- a/src/main/java/core/packetproxy/ProxyXmppSSLForward.java
+++ b/src/main/java/core/packetproxy/ProxyXmppSSLForward.java
@@ -17,6 +17,7 @@ package packetproxy;
 
 import static packetproxy.http.Https.createSSLContext;
 import static packetproxy.http.Https.createSSLSocketFactory;
+import static packetproxy.util.Logging.log;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -27,7 +28,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import packetproxy.common.Endpoint;
 import packetproxy.common.SocketEndpoint;
 import packetproxy.model.ListenPort;
-import packetproxy.util.PacketProxyUtility;
 
 public class ProxyXmppSSLForward extends Proxy {
 
@@ -47,7 +47,7 @@ public class ProxyXmppSSLForward extends Proxy {
 			try {
 
 				Socket client = listen_socket.accept();
-				PacketProxyUtility.getInstance().packetProxyLog("accept");
+				log("accept");
 
 				Socket server = new Socket();
 				server.connect(listen_info.getServer().getAddress());

--- a/src/main/java/core/packetproxy/Simplex.java
+++ b/src/main/java/core/packetproxy/Simplex.java
@@ -15,6 +15,9 @@
  */
 package packetproxy;
 
+import static packetproxy.util.Logging.errWithStackTrace;
+import static packetproxy.util.Logging.log;
+
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -29,7 +32,6 @@ import java.util.concurrent.TimeoutException;
 import javax.net.ssl.SSLException;
 import javax.swing.event.EventListenerList;
 import org.apache.commons.lang3.ArrayUtils;
-import packetproxy.util.PacketProxyUtility;
 
 class Simplex extends Thread {
 
@@ -191,7 +193,6 @@ class Simplex extends Thread {
 
 	@Override
 	public void run() {
-		PacketProxyUtility util = PacketProxyUtility.getInstance();
 		if (in == null) {
 
 			return;
@@ -266,17 +267,17 @@ class Simplex extends Thread {
 		} catch (TimeoutException e) {
 
 			e.printStackTrace();
-			util.packetProxyLogErrWithStackTrace(e);
-			util.packetProxyLog("-----");
-			util.packetProxyLog(new String(bout.toByteArray()));
-			util.packetProxyLog("-----");
+			errWithStackTrace(e);
+			log("-----");
+			log(new String(bout.toByteArray()));
+			log("-----");
 			try {
 
 				in.close();
 			} catch (Exception e1) {
 
 				e1.printStackTrace();
-				util.packetProxyLogErrWithStackTrace(e);
+				errWithStackTrace(e);
 			}
 		} catch (SSLException e) {
 
@@ -287,7 +288,7 @@ class Simplex extends Thread {
 		} catch (Exception e) {
 
 			e.printStackTrace();
-			util.packetProxyLogErrWithStackTrace(e);
+			errWithStackTrace(e);
 		} finally {
 
 			executor.shutdownNow();
@@ -302,7 +303,7 @@ class Simplex extends Thread {
 				} catch (Exception e1) {
 
 					e1.printStackTrace();
-					util.packetProxyLogErrWithStackTrace(e1);
+					errWithStackTrace(e1);
 				}
 				try {
 
@@ -311,7 +312,7 @@ class Simplex extends Thread {
 				} catch (Exception e1) {
 
 					e1.printStackTrace();
-					util.packetProxyLogErrWithStackTrace(e1);
+					errWithStackTrace(e1);
 				}
 			}
 		}

--- a/src/main/java/core/packetproxy/common/BinaryBuffer.java
+++ b/src/main/java/core/packetproxy/common/BinaryBuffer.java
@@ -15,8 +15,9 @@
  */
 package packetproxy.common;
 
+import static packetproxy.util.Logging.log;
+
 import org.apache.commons.lang3.ArrayUtils;
-import packetproxy.util.PacketProxyUtility;
 
 public class BinaryBuffer {
 	/*
@@ -109,8 +110,7 @@ public class BinaryBuffer {
 		// }
 		if (data_size < index + length) {
 
-			PacketProxyUtility.getInstance().packetProxyLog("[Error] Something wrong (%d < %d + %d)", data_size, index,
-					length);
+			log("[Error] Something wrong (%d < %d + %d)", data_size, index, length);
 			return;
 		}
 		data_size_in_utf8 -= new String(buffer, index, length).length();

--- a/src/main/java/core/packetproxy/common/JWT.java
+++ b/src/main/java/core/packetproxy/common/JWT.java
@@ -15,11 +15,12 @@
  */
 package packetproxy.common;
 
+import static packetproxy.util.Logging.log;
+
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import net.arnx.jsonic.JSON;
-import packetproxy.util.PacketProxyUtility;
 
 public class JWT {
 
@@ -75,8 +76,8 @@ public class JWT {
 	}
 
 	public void debug() {
-		PacketProxyUtility.getInstance().packetProxyLog(header);
-		PacketProxyUtility.getInstance().packetProxyLog(payload);
+		log(header);
+		log(payload);
 	}
 
 	public String toJwtString() throws Exception {

--- a/src/main/java/core/packetproxy/common/UniqueID.java
+++ b/src/main/java/core/packetproxy/common/UniqueID.java
@@ -15,7 +15,7 @@
  */
 package packetproxy.common;
 
-import packetproxy.util.PacketProxyUtility;
+import static packetproxy.util.Logging.err;
 
 // ローカルPC の現在時刻（ミリ秒単位）を利用したユニークな自動採番クラス
 // かならず昇順の番号を採番するため、ソートするのに便利
@@ -47,7 +47,7 @@ public class UniqueID {
 				continue;
 			} else if (newId < lastId) {
 
-				PacketProxyUtility.getInstance().packetProxyLogErr("Time of your pc seemed to be changed...");
+				err("Time of your pc seemed to be changed...");
 			}
 			return lastId = newId;
 		}

--- a/src/main/java/core/packetproxy/common/Utils.java
+++ b/src/main/java/core/packetproxy/common/Utils.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.common;
 
+import static packetproxy.util.Logging.err;
+
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +26,6 @@ import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.ArrayUtils;
-import packetproxy.util.PacketProxyUtility;
 
 public class Utils {
 
@@ -137,7 +138,7 @@ public class Utils {
 		}
 		if (berr.size() > 0) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr(berr.toString());
+			err(berr.toString());
 		}
 		return bout.toByteArray();
 	}
@@ -165,7 +166,7 @@ public class Utils {
 		}
 		if (berr.size() > 0) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr(berr.toString());
+			err(berr.toString());
 		}
 		return bout.toByteArray();
 	}

--- a/src/main/java/core/packetproxy/controller/ResendController.java
+++ b/src/main/java/core/packetproxy/controller/ResendController.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.controller;
 
+import static packetproxy.util.Logging.err;
+
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
@@ -31,7 +33,6 @@ import packetproxy.encode.Encoder;
 import packetproxy.http.Http;
 import packetproxy.model.OneShotPacket;
 import packetproxy.model.Packet;
-import packetproxy.util.PacketProxyUtility;
 
 public class ResendController {
 
@@ -94,7 +95,6 @@ public class ResendController {
 
 	public static class ResendWorker extends SwingWorker<Object, OneShotPacket> {
 
-		private PacketProxyUtility util;
 		int count;
 		OneShotPacket oneshot;
 		OneShotPacket[] oneshots;
@@ -140,7 +140,7 @@ public class ResendController {
 					}
 				} else {
 
-					util.packetProxyLogErr("Resend packet is wrong!");
+					err("Resend packet is wrong!");
 					return null;
 				}
 
@@ -167,8 +167,8 @@ public class ResendController {
 
 			} catch (SocketTimeoutException e) {
 
-				PacketProxyUtility.getInstance().packetProxyLogErr("Resend Connection is timeout!");
-				PacketProxyUtility.getInstance().packetProxyLogErr("All resend packets are dropped.");
+				err("Resend Connection is timeout!");
+				err("All resend packets are dropped.");
 				e.printStackTrace();
 				return null;
 			} catch (Exception e) {
@@ -208,8 +208,7 @@ public class ResendController {
 					Duplex original_duplex = DuplexManager.getInstance().getDuplex(oneshot.getConn());
 					if (original_duplex == null) {
 
-						PacketProxyUtility.getInstance().packetProxyLogErr(I18nString
-								.get("[Error] tried to resend packets, but the connection was already closed."));
+						err(I18nString.get("[Error] tried to resend packets, but the connection was already closed."));
 						return;
 					}
 					this.duplex = DuplexFactory.createDuplexFromOriginalDuplex(original_duplex, this.oneshot);

--- a/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
+++ b/src/main/java/core/packetproxy/encode/EncodeAmazonLexV2.java
@@ -15,11 +15,12 @@
  */
 package packetproxy.encode;
 
+import static packetproxy.util.Logging.log;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import packetproxy.common.AmazonLexV2;
 import packetproxy.http.Http;
-import packetproxy.util.PacketProxyUtility;
 
 public class EncodeAmazonLexV2 extends EncodeHTTPBase {
 
@@ -44,13 +45,11 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase {
 
 	@Override
 	protected Http decodeServerResponseHttp(Http inputHttp) throws Exception {
-		PacketProxyUtility util = PacketProxyUtility.getInstance();
 		var contentType = inputHttp.getFirstHeader("Content-Type");
 		if (!contentType.startsWith("application/vnd.amazon.eventstream")) {
 
-			util.packetProxyLog(
-					"[EncodeAmazonLexV2] decodeServerResponseHttp: Content-type is not specified or other content-type detected: "
-							+ contentType);
+			log("[EncodeAmazonLexV2] decodeServerResponseHttp: Content-type is not specified or other content-type detected: %s",
+					contentType);
 			return inputHttp;
 		}
 		byte[] body = inputHttp.getBody();
@@ -67,20 +66,18 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase {
 
 	@Override
 	protected Http encodeServerResponseHttp(Http inputHttp) throws Exception {
-		PacketProxyUtility util = PacketProxyUtility.getInstance();
 		var contentType = inputHttp.getFirstHeader("Content-Type");
 		if (!contentType.startsWith("application/vnd.amazon.eventstream")) {
 
-			util.packetProxyLog(
-					"[EncodeAmazonLexV2] encodeServerResponseHttp: Content-type is not specified or other content-type detected: "
-							+ contentType);
+			log("[EncodeAmazonLexV2] encodeServerResponseHttp: Content-type is not specified or other content-type detected: %s",
+					contentType);
 			return inputHttp;
 		}
 
 		byte[] body = inputHttp.getBody();
 		if (body.length == 0) {
 
-			util.packetProxyLog("[EncodeAmazonLexV2] Warning: Empty body detected, skipping encoding.");
+			log("[EncodeAmazonLexV2] Warning: Empty body detected, skipping encoding.");
 			return inputHttp;
 		}
 
@@ -90,8 +87,7 @@ public class EncodeAmazonLexV2 extends EncodeHTTPBase {
 
 		if (lex == null) {
 
-			util.packetProxyLog(
-					"[EncodeAmazonLexV2] Warning: Invalid Amazon Lex V2 Event Stream detected, skipping encoding.");
+			log("[EncodeAmazonLexV2] Warning: Invalid Amazon Lex V2 Event Stream detected, skipping encoding.");
 			return inputHttp;
 		}
 

--- a/src/main/java/core/packetproxy/extensions/randomness/RandomnessExtension.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/RandomnessExtension.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.extensions.randomness;
 
+import static packetproxy.util.Logging.log;
+
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import java.awt.BasicStroke;
@@ -65,7 +67,6 @@ import packetproxy.gui.GUIPacket;
 import packetproxy.model.Extension;
 import packetproxy.model.OneShotPacket;
 import packetproxy.model.Packet;
-import packetproxy.util.PacketProxyUtility;
 
 public class RandomnessExtension extends Extension {
 
@@ -195,7 +196,7 @@ public class RandomnessExtension extends Extension {
 										requestProgressBar.setValue(requestProgressBar.getValue() + oneshots.size());
 										if (recvPackets.size() == count) {
 
-											PacketProxyUtility.getInstance().packetProxyLog("all packet received");
+											log("all packet received");
 											for (Map.Entry<Integer, OneShotPacket> entry : recvPackets.entrySet()) {
 
 												OneShotPacket packet = entry.getValue();
@@ -212,7 +213,8 @@ public class RandomnessExtension extends Extension {
 													tokens.add(token);
 												}
 											}
-											JOptionPane.showMessageDialog(owner, "get " + tokens.size() + " tokens",
+											JOptionPane.showMessageDialog(owner,
+													String.format("get %d tokens", tokens.size()),
 													"Packet collection finished", JOptionPane.PLAIN_MESSAGE);
 										}
 									}

--- a/src/main/java/core/packetproxy/extensions/randomness/test/LinearComplexityTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/LinearComplexityTest.java
@@ -3,8 +3,9 @@ package packetproxy.extensions.randomness.test;
 
 // https://www.nist.gov/disclaimer
 
+import static packetproxy.util.Logging.log;
+
 import org.apache.commons.math3.distribution.GammaDistribution;
-import packetproxy.util.PacketProxyUtility;
 
 public class LinearComplexityTest extends RandomnessTest {
 
@@ -20,8 +21,7 @@ public class LinearComplexityTest extends RandomnessTest {
 		int N = e.length / M;
 		if (N == 0) {
 
-			PacketProxyUtility.getInstance()
-					.packetProxyLog("[Warn] bit length is not suitable for Rank test. Please collect more tokens.");
+			log("[Warn] bit length is not suitable for Rank test. Please collect more tokens.");
 			return new double[e.length > 0 ? e[0].length : 0];
 		}
 

--- a/src/main/java/core/packetproxy/extensions/randomness/test/LongestRunOfOneTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/LongestRunOfOneTest.java
@@ -3,8 +3,9 @@ package packetproxy.extensions.randomness.test;
 
 // https://www.nist.gov/disclaimer
 
+import static packetproxy.util.Logging.log;
+
 import org.apache.commons.math3.distribution.GammaDistribution;
-import packetproxy.util.PacketProxyUtility;
 
 public class LongestRunOfOneTest extends RandomnessTest {
 
@@ -12,8 +13,7 @@ public class LongestRunOfOneTest extends RandomnessTest {
 		int n = e.length;
 		if (n < 128) {
 
-			PacketProxyUtility.getInstance().packetProxyLog(
-					"[Warn] bit length is not suitable for LongestRunOfOne test. Please collect more tokens.");
+			log("[Warn] bit length is not suitable for LongestRunOfOne test. Please collect more tokens.");
 			return new double[e.length > 0 ? e[0].length : 0];
 		}
 		int K = 0, M = 0;

--- a/src/main/java/core/packetproxy/extensions/randomness/test/RankTest.java
+++ b/src/main/java/core/packetproxy/extensions/randomness/test/RankTest.java
@@ -3,10 +3,11 @@ package packetproxy.extensions.randomness.test;
 
 // https://www.nist.gov/disclaimer
 
+import static packetproxy.util.Logging.log;
+
 import org.apache.commons.math3.distribution.GammaDistribution;
 import org.ejml.simple.SimpleMatrix;
 import org.ejml.simple.SimpleSVD;
-import packetproxy.util.PacketProxyUtility;
 
 public class RankTest extends RandomnessTest {
 
@@ -14,8 +15,7 @@ public class RankTest extends RandomnessTest {
 		int N = e.length / (32 * 32);
 		if (N == 0) {
 
-			PacketProxyUtility.getInstance()
-					.packetProxyLog("[Warn] bit length is not suitable for Rank test. Please collect more tokens.");
+			log("[Warn] bit length is not suitable for Rank test. Please collect more tokens.");
 			return new double[e.length > 0 ? e[0].length : 0];
 		}
 

--- a/src/main/java/core/packetproxy/gui/GUIBulkSenderTable.java
+++ b/src/main/java/core/packetproxy/gui/GUIBulkSenderTable.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.util.Logging.log;
+
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
@@ -39,7 +41,6 @@ import packetproxy.common.Utils;
 import packetproxy.model.OneShotPacket;
 import packetproxy.model.OptionTableModel;
 import packetproxy.model.RegexParam;
-import packetproxy.util.PacketProxyUtility;
 
 public class GUIBulkSenderTable {
 
@@ -160,7 +161,7 @@ public class GUIBulkSenderTable {
 				public void actionPerformed(ActionEvent actionEvent) {
 					try {
 
-						PacketProxyUtility.getInstance().packetProxyLog("TODO");
+						log("TODO");
 						JFrame owner = GUIMain.getInstance();
 						int packetId = getSelectedPacketId();
 						GUIRegexParamsTableDialog dlg = new GUIRegexParamsTableDialog(owner, regexParams, packetId);

--- a/src/main/java/core/packetproxy/gui/GUIData.java
+++ b/src/main/java/core/packetproxy/gui/GUIData.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.util.Logging.log;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Toolkit;
@@ -40,7 +42,6 @@ import packetproxy.model.DiffJson;
 import packetproxy.model.Packet;
 import packetproxy.model.Packets;
 import packetproxy.util.CharSetUtility;
-import packetproxy.util.PacketProxyUtility;
 
 public class GUIData {
 
@@ -324,7 +325,7 @@ public class GUIData {
 					}
 					origIndex = GUIHistory.getInstance().getSelectedIndex();
 					GUIHistory.getInstance().addCustomColoringToCursorPos(new Color(0xb0, 0xb0, 0xb0)); // Gray
-					PacketProxyUtility.getInstance().packetProxyLog("Diff: original text was saved!");
+					log("Diff: original text was saved!");
 				} catch (Exception e1) {
 
 					e1.printStackTrace();

--- a/src/main/java/core/packetproxy/gui/GUIFilterDropDownList.java
+++ b/src/main/java/core/packetproxy/gui/GUIFilterDropDownList.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.util.Logging.err;
+
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
@@ -35,7 +37,6 @@ import javax.swing.table.TableCellRenderer;
 import packetproxy.common.I18nString;
 import packetproxy.model.Filter;
 import packetproxy.model.Filters;
-import packetproxy.util.PacketProxyUtility;
 
 public class GUIFilterDropDownList extends JDialog {
 
@@ -128,7 +129,7 @@ public class GUIFilterDropDownList extends JDialog {
 						consumer.accept(new Filter(name, filter));
 					} else {
 
-						PacketProxyUtility.getInstance().packetProxyLogErr(Integer.toString(idx));
+						err(Integer.toString(idx));
 					}
 				} catch (Exception e1) {
 

--- a/src/main/java/core/packetproxy/gui/GUIHistoryAutoScroll.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistoryAutoScroll.java
@@ -15,13 +15,13 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.util.Logging.err;
+
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
-import packetproxy.util.PacketProxyUtility;
 
-@SuppressWarnings("serial")
 public class GUIHistoryAutoScroll extends JLabel {
 
 	private static ImageIcon disabledIcon = new ImageIcon(
@@ -60,7 +60,7 @@ public class GUIHistoryAutoScroll extends JLabel {
 
 			setIcon(enabledIcon);
 			isEnabled = true;
-			PacketProxyUtility.getInstance().packetProxyLogErr("Auto scrolling was turned ON!");
+			err("Auto scrolling was turned ON!");
 		}
 	}
 
@@ -69,7 +69,7 @@ public class GUIHistoryAutoScroll extends JLabel {
 
 			setIcon(disabledIcon);
 			isEnabled = false;
-			PacketProxyUtility.getInstance().packetProxyLogErr("Auto scrolling was turned OFF");
+			err("Auto scrolling was turned OFF");
 		}
 	}
 

--- a/src/main/java/core/packetproxy/gui/GUIMain.java
+++ b/src/main/java/core/packetproxy/gui/GUIMain.java
@@ -16,6 +16,7 @@
 package packetproxy.gui;
 
 import static javax.swing.JOptionPane.YES_NO_OPTION;
+import static packetproxy.util.Logging.errWithStackTrace;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -144,7 +145,7 @@ public class GUIMain extends JFrame implements PropertyChangeListener {
 			gui_history.updateAllAsync();
 		} catch (Exception e) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErrWithStackTrace(e);
+			errWithStackTrace(e);
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/core/packetproxy/gui/GUIOption.java
+++ b/src/main/java/core/packetproxy/gui/GUIOption.java
@@ -15,6 +15,9 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.util.Logging.err;
+import static packetproxy.util.Logging.log;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -35,7 +38,6 @@ import packetproxy.model.CAFactory;
 import packetproxy.model.CAs.CA;
 import packetproxy.model.CAs.PacketProxyCAPerUser;
 import packetproxy.model.InterceptOptions;
-import packetproxy.util.PacketProxyUtility;
 
 public class GUIOption {
 
@@ -212,7 +214,6 @@ public class GUIOption {
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				PacketProxyUtility util = PacketProxyUtility.getInstance();
 				try {
 
 					String name = ca_combo.getSelectedItem().toString();
@@ -223,12 +224,12 @@ public class GUIOption {
 							JOptionPane.WARNING_MESSAGE);
 					if (option == JOptionPane.YES_OPTION) {
 
-						util.packetProxyLog("regenerate " + name);
+						log("regenerate %s", name);
 						ca.regenerateCA();
 					}
 				} catch (Exception exp) {
 
-					util.packetProxyLogErr("RegenerateCertButton Action Error: " + exp.getMessage());
+					err("RegenerateCertButton Action Error: %s", exp.getMessage());
 				}
 			}
 		});

--- a/src/main/java/core/packetproxy/gui/GUIOptionListenPortDialog.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionListenPortDialog.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.util.Logging.log;
+
 import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Rectangle;
@@ -39,7 +41,6 @@ import packetproxy.model.CAFactory;
 import packetproxy.model.ListenPort;
 import packetproxy.model.Server;
 import packetproxy.model.Servers;
-import packetproxy.util.PacketProxyUtility;
 
 public class GUIOptionListenPortDialog extends JDialog {
 
@@ -288,11 +289,11 @@ public class GUIOptionListenPortDialog extends JDialog {
 						type = ListenPort.TYPE.UDP_FORWARDER;
 					} else if (type_combo.getSelectedItem().toString().equals("SSL_TRANSPARENT_PROXY")) {
 
-						PacketProxyUtility.getInstance().packetProxyLog("SSL_TRANSPARENT_PROXY created");
+						log("SSL_TRANSPARENT_PROXY created");
 						type = ListenPort.TYPE.SSL_TRANSPARENT_PROXY;
 					} else if (type_combo.getSelectedItem().toString().equals("HTTP_TRANSPARENT_PROXY")) {
 
-						PacketProxyUtility.getInstance().packetProxyLog("HTTP_TRANSPARENT_PROXY created");
+						log("HTTP_TRANSPARENT_PROXY created");
 						type = ListenPort.TYPE.HTTP_TRANSPARENT_PROXY;
 					} else if (type_combo.getSelectedItem().toString().equals("XMPP_SSL_FORWARDER")) {
 

--- a/src/main/java/core/packetproxy/gui/GUIOptionModifications.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionModifications.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.util.Logging.log;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -24,7 +26,6 @@ import java.util.List;
 import javax.swing.JFrame;
 import packetproxy.model.Modification;
 import packetproxy.model.Modifications;
-import packetproxy.util.PacketProxyUtility;
 
 public class GUIOptionModifications extends GUIOptionComponentBase<Modification> {
 
@@ -80,7 +81,7 @@ public class GUIOptionModifications extends GUIOptionComponentBase<Modification>
 						mod.setEnabled();
 						modifications.create(mod);
 					}
-					PacketProxyUtility.getInstance().packetProxyLog("Modification button is pressed.");
+					log("Modification button is pressed.");
 				} catch (Exception e1) {
 
 					e1.printStackTrace();

--- a/src/main/java/core/packetproxy/gui/TabSet.java
+++ b/src/main/java/core/packetproxy/gui/TabSet.java
@@ -16,6 +16,7 @@
 package packetproxy.gui;
 
 import static packetproxy.model.PropertyChangeEventType.SELECTED_INDEX;
+import static packetproxy.util.Logging.err;
 
 import java.awt.BorderLayout;
 import java.beans.PropertyChangeListener;
@@ -129,8 +130,7 @@ public class TabSet {
 			case 2 :
 				return json_panel.getData();
 			default :
-				PacketProxyUtility.getInstance()
-						.packetProxyLogErr("Not effective index, though this returns raw_panel data in such case.");
+				err("Not effective index, though this returns raw_panel data in such case.");
 				return raw_panel.getData();
 		}
 	}
@@ -182,8 +182,7 @@ public class TabSet {
 					json_panel.setData(PacketProxyUtility.getInstance().prettyFormatJSONInRawData(data));
 					break;
 				default :
-					PacketProxyUtility.getInstance()
-							.packetProxyLogErr("Not effective index, though this returns raw_panel data in such case.");
+					err("Not effective index, though this returns raw_panel data in such case.");
 					break;
 			}
 			if (searchBox == null) {
@@ -205,8 +204,7 @@ public class TabSet {
 					searchBox.setBaseText(json_panel.getTextPane(), emphasis);
 					break;
 				default :
-					PacketProxyUtility.getInstance()
-							.packetProxyLogErr("Not effective index, though this returns raw_panel data in such case.");
+					err("Not effective index, though this returns raw_panel data in such case.");
 					break;
 			}
 			searchBox.textChanged();

--- a/src/main/java/core/packetproxy/http/HeaderField.java
+++ b/src/main/java/core/packetproxy/http/HeaderField.java
@@ -15,7 +15,7 @@
  */
 package packetproxy.http;
 
-import packetproxy.util.PacketProxyUtility;
+import static packetproxy.util.Logging.err;
 
 public class HeaderField {
 
@@ -29,7 +29,7 @@ public class HeaderField {
 			value = fields[1].trim();
 		} else {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr("invalid header field");
+			err("invalid header field");
 			new Throwable().printStackTrace();
 		}
 	}

--- a/src/main/java/core/packetproxy/http/Http.java
+++ b/src/main/java/core/packetproxy/http/Http.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.http;
 
+import static packetproxy.util.Logging.log;
+
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import java.io.ByteArrayInputStream;
@@ -36,7 +38,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import packetproxy.PrivateDNSClient;
 import packetproxy.common.Parameter;
 import packetproxy.common.Utils;
-import packetproxy.util.PacketProxyUtility;
 
 public class Http {
 
@@ -472,8 +473,7 @@ public class Http {
 
 					// 多分httpsだけど、httpだと原因を探すのが大変になるので一応エラー出力しておく
 					flag_proxy_ssl = true;
-					PacketProxyUtility.getInstance()
-							.packetProxyLog(status_line + " can't distinguish HTTP or HTTPS, but use HTTPS");
+					log("%s can't distinguish HTTP or HTTPS, but use HTTPS", status_line);
 				}
 			} else {
 

--- a/src/main/java/core/packetproxy/model/Database.java
+++ b/src/main/java/core/packetproxy/model/Database.java
@@ -16,6 +16,8 @@
 package packetproxy.model;
 
 import static packetproxy.model.PropertyChangeEventType.DATABASE_MESSAGE;
+import static packetproxy.util.Logging.err;
+import static packetproxy.util.Logging.log;
 
 import com.j256.ormlite.dao.Dao;
 import com.j256.ormlite.dao.DaoManager;
@@ -32,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import packetproxy.util.PacketProxyUtility;
 
 public class Database {
 
@@ -57,19 +58,18 @@ public class Database {
 	}
 
 	private void createDB() throws Exception {
-		PacketProxyUtility util = PacketProxyUtility.getInstance();
 		if (!Files.exists(databaseDir)) {
 
-			util.packetProxyLog(databaseDir.toAbsolutePath() + " directory is not found...");
-			util.packetProxyLog("creating the directory...");
+			log("%s directory is not found...", databaseDir.toAbsolutePath());
+			log("creating the directory...");
 			Files.createDirectories(databaseDir);
 			System.out.println("success!");
 		} else {
 
 			if (!Files.isDirectory(databaseDir)) {
 
-				util.packetProxyLogErr(databaseDir.toAbsolutePath() + " file is not directory...");
-				util.packetProxyLogErr("Must be a directory");
+				err("%s file is not directory...", databaseDir.toAbsolutePath());
+				err("Must be a directory");
 				System.exit(1);
 			}
 		}
@@ -180,9 +180,8 @@ public class Database {
 					conn.executeStatement(query, DatabaseConnection.DEFAULT_RESULT_FLAGS);
 				} catch (Exception e) {
 
-					PacketProxyUtility.getInstance().packetProxyLog(
-							"Database format may have been changed. Simply ignore this type of errors.");
-					PacketProxyUtility.getInstance().packetProxyLog("[Error] %s", query);
+					log("Database format may have been changed. Simply ignore this type of errors.");
+					log("[Error] %s", query);
 				}
 			}
 			conn.close();

--- a/src/main/java/core/packetproxy/model/OneShotPacket.java
+++ b/src/main/java/core/packetproxy/model/OneShotPacket.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.model;
 
+import static packetproxy.util.Logging.err;
+
 import java.net.InetSocketAddress;
 import org.apache.commons.lang3.ArrayUtils;
 import packetproxy.EncoderManager;
@@ -22,7 +24,6 @@ import packetproxy.common.Range;
 import packetproxy.common.Utils;
 import packetproxy.encode.Encoder;
 import packetproxy.model.Packet.Direction;
-import packetproxy.util.PacketProxyUtility;
 
 public class OneShotPacket implements PacketInfo, Cloneable {
 
@@ -188,7 +189,7 @@ public class OneShotPacket implements PacketInfo, Cloneable {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, alpn);
 		if (encoder == null) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
+			err("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", alpn);
 		}
 		return (getDirection() == Direction.CLIENT) ? encoder.getSummarizedRequest(toPacket()) : "";
@@ -198,7 +199,7 @@ public class OneShotPacket implements PacketInfo, Cloneable {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, alpn);
 		if (encoder == null) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
+			err("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", alpn);
 		}
 		return (getDirection() == Direction.SERVER) ? encoder.getSummarizedResponse(toPacket()) : "";

--- a/src/main/java/core/packetproxy/model/Packet.java
+++ b/src/main/java/core/packetproxy/model/Packet.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.model;
 
+import static packetproxy.util.Logging.err;
+
 import com.j256.ormlite.field.DataType;
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
@@ -22,7 +24,6 @@ import java.net.InetSocketAddress;
 import java.util.Date;
 import packetproxy.EncoderManager;
 import packetproxy.encode.Encoder;
-import packetproxy.util.PacketProxyUtility;
 
 @DatabaseTable(tableName = "packets")
 public class Packet implements PacketInfo {
@@ -274,7 +275,7 @@ public class Packet implements PacketInfo {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, null);
 		if (encoder == null) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
+			err("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", null);
 		}
 		return (getDirection() == Direction.CLIENT) ? encoder.getSummarizedRequest(this) : "";
@@ -284,7 +285,7 @@ public class Packet implements PacketInfo {
 		Encoder encoder = EncoderManager.getInstance().createInstance(encoder_name, null);
 		if (encoder == null) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
+			err("エンコードモジュール: %s が見当たらないので、Sample とみなしました", encoder_name);
 			encoder = EncoderManager.getInstance().createInstance("Sample", null);
 		}
 		return (getDirection() == Direction.SERVER) ? encoder.getSummarizedResponse(this) : "";

--- a/src/main/java/core/packetproxy/model/Packets.java
+++ b/src/main/java/core/packetproxy/model/Packets.java
@@ -17,6 +17,7 @@ package packetproxy.model;
 
 import static packetproxy.model.PropertyChangeEventType.DATABASE_MESSAGE;
 import static packetproxy.model.PropertyChangeEventType.PACKETS;
+import static packetproxy.util.Logging.log;
 
 import com.j256.ormlite.dao.Dao;
 import java.beans.PropertyChangeEvent;
@@ -28,7 +29,6 @@ import java.util.concurrent.Executors;
 import javax.swing.JOptionPane;
 import packetproxy.common.Logger;
 import packetproxy.model.Database.DatabaseMessage;
-import packetproxy.util.PacketProxyUtility;
 
 public class Packets implements PropertyChangeListener {
 
@@ -60,18 +60,16 @@ public class Packets implements PropertyChangeListener {
 		changes.removePropertyChangeListener(listener);
 	}
 
-	private PacketProxyUtility util;
 	private Database database;
 	private Dao<Packet, Integer> dao;
 	private ExecutorService executor;
 
 	private Packets(boolean restore) throws Exception {
-		util = PacketProxyUtility.getInstance();
 		database = Database.getInstance();
 		database.addPropertyChangeListener(this);
 		if (!restore) {
 
-			util.packetProxyLog("drop history...");
+			log("drop history...");
 			database.dropPacketTableFaster();
 		}
 		dao = database.createTable(Packet.class);
@@ -81,8 +79,8 @@ public class Packets implements PropertyChangeListener {
 
 				RecreateTable();
 			}
-			util.packetProxyLog("load history...");
-			util.packetProxyLog("load" + dao.countOf() + " records.");
+			log("load history...");
+			log("load %d records.", dao.countOf());
 		}
 		executor = Executors.newSingleThreadExecutor();
 	}

--- a/src/main/java/core/packetproxy/model/Server.java
+++ b/src/main/java/core/packetproxy/model/Server.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.model;
 
+import static packetproxy.util.Logging.err;
+
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
 import java.net.InetAddress;
@@ -24,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import packetproxy.PrivateDNSClient;
-import packetproxy.util.PacketProxyUtility;
 
 @DatabaseTable(tableName = "servers")
 public class Server {
@@ -199,8 +200,7 @@ public class Server {
 			}
 		} catch (UnknownHostException e) {
 
-			PacketProxyUtility.getInstance()
-					.packetProxyLogErr("Nonexistent server '%s' is specified in config [DNS resolv error]", ip);
+			err("Nonexistent server '%s' is specified in config [DNS resolv error]", ip);
 			return new ArrayList<InetAddress>();
 		} catch (Exception e) {
 

--- a/src/main/java/core/packetproxy/ppcontextmenu/PPContextMenu.java
+++ b/src/main/java/core/packetproxy/ppcontextmenu/PPContextMenu.java
@@ -15,11 +15,12 @@
  */
 package packetproxy.ppcontextmenu;
 
+import static packetproxy.util.Logging.log;
+
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.HashMap;
 import javax.swing.JMenuItem;
-import packetproxy.util.PacketProxyUtility;
 
 public abstract class PPContextMenu {
 
@@ -40,8 +41,7 @@ public abstract class PPContextMenu {
 					action();
 				} catch (Exception e) {
 
-					PacketProxyUtility.getInstance()
-							.packetProxyLog("Error: " + getLabelName() + " module something happened.");
+					log("Error: %s module something happened.", getLabelName());
 					e.printStackTrace();
 				}
 			}

--- a/src/main/java/core/packetproxy/quic/service/framegenerator/helper/ReceivedPacketNumbers.java
+++ b/src/main/java/core/packetproxy/quic/service/framegenerator/helper/ReceivedPacketNumbers.java
@@ -16,8 +16,9 @@
 
 package packetproxy.quic.service.framegenerator.helper;
 
+import static packetproxy.util.Logging.err;
+
 import java.util.TreeSet;
-import packetproxy.util.PacketProxyUtility;
 
 public class ReceivedPacketNumbers {
 
@@ -43,8 +44,7 @@ public class ReceivedPacketNumbers {
 		assert (smallestValid <= largestOfRange);
 		if (unreceivedPacketNumbers.contains(largestOfRange)) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr("[QUIC] Error: AckRange: %d isn't in ack_range",
-					largestOfRange);
+			err("[QUIC] Error: AckRange: %d isn't in ack_range", largestOfRange);
 			return 0;
 		}
 		return getSmallestReceived(largestOfRange, smallestValid);
@@ -54,7 +54,7 @@ public class ReceivedPacketNumbers {
 		assert (smallestValid <= largestOfGap);
 		if (!unreceivedPacketNumbers.contains(largestOfGap)) {
 
-			PacketProxyUtility.getInstance().packetProxyLogErr("[QUIC] Error: AckRange: %d isn't in gap", largestOfGap);
+			err("[QUIC] Error: AckRange: %d isn't in gap", largestOfGap);
 			return 0;
 		}
 		return getSmallestUnreceived(largestOfGap, smallestValid);

--- a/src/main/java/core/packetproxy/quic/service/pnspace/PnSpace.java
+++ b/src/main/java/core/packetproxy/quic/service/pnspace/PnSpace.java
@@ -20,6 +20,7 @@ import static packetproxy.quic.service.handshake.HandshakeState.State.Confirmed;
 import static packetproxy.quic.utils.Constants.*;
 import static packetproxy.quic.utils.Constants.PnSpaceType.PnSpaceHandshake;
 import static packetproxy.quic.utils.Constants.PnSpaceType.PnSpaceInitial;
+import static packetproxy.util.Logging.err;
 import static packetproxy.util.Throwing.rethrow;
 
 import java.io.OutputStream;
@@ -44,7 +45,6 @@ import packetproxy.quic.value.SentPacket;
 import packetproxy.quic.value.frame.*;
 import packetproxy.quic.value.packet.PnSpacePacket;
 import packetproxy.quic.value.packet.QuicPacket;
-import packetproxy.util.PacketProxyUtility;
 
 @Getter
 public abstract class PnSpace {
@@ -186,8 +186,7 @@ public abstract class PnSpace {
 			} else if (frame instanceof ConnectionCloseFrame) {
 
 				ConnectionCloseFrame connCloseFrame = (ConnectionCloseFrame) frame;
-				PacketProxyUtility.getInstance().packetProxyLogErr("HTTP3 connection closed (%s)",
-						connCloseFrame.getReasonPhraseString());
+				err("HTTP3 connection closed (%s)", connCloseFrame.getReasonPhraseString());
 				this.conn.close();
 			} else if (frame instanceof NewConnectionIdFrame) {
 

--- a/src/main/java/core/packetproxy/util/CharSetUtility.java
+++ b/src/main/java/core/packetproxy/util/CharSetUtility.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.util;
 
+import static packetproxy.util.Logging.log;
+
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -227,7 +229,7 @@ public class CharSetUtility {
 					return;
 				}
 			}
-			PacketProxyUtility.getInstance().packetProxyLog("%s is not supported charset", charSet);
+			log("%s is not supported charset", charSet);
 		}
 		if (getAvailableCharSetList().contains(charSet)) {
 
@@ -235,7 +237,7 @@ public class CharSetUtility {
 		} else {
 
 			// TODO: Throw Exception
-			PacketProxyUtility.getInstance().packetProxyLog("%s is not supported charset", charSet);
+			log("%s is not supported charset", charSet);
 		}
 	}
 

--- a/src/main/java/core/packetproxy/util/Logging.java
+++ b/src/main/java/core/packetproxy/util/Logging.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import packetproxy.gui.GUILog;
+
+public class Logging {
+
+	private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+	private static final GUILog guiLog = GUILog.getInstance();
+
+	private Logging() {
+	}
+
+	public static void log(String format, Object... args) {
+		LocalDateTime now = LocalDateTime.now();
+		String ns = dtf.format(now);
+		String ss = ns + "       " + String.format(format, args);
+		System.out.println(ss);
+		guiLog.append(ss);
+	}
+
+	public static void err(String format, Object... args) {
+		LocalDateTime now = LocalDateTime.now();
+		String ns = dtf.format(now);
+		String ss = ns + "       " + String.format(format, args);
+		System.err.println(ss);
+		guiLog.appendErr(ss);
+	}
+
+	public static void errWithStackTrace(Throwable e) {
+		err(e.getMessage());
+		StackTraceElement[] stackTrace = e.getStackTrace();
+		for (var element : stackTrace) {
+			err(element.toString());
+		}
+	}
+}

--- a/src/main/java/core/packetproxy/util/PacketProxyUtility.java
+++ b/src/main/java/core/packetproxy/util/PacketProxyUtility.java
@@ -16,81 +16,34 @@
 package packetproxy.util;
 
 import java.io.UnsupportedEncodingException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import packetproxy.gui.GUILog;
 
 public class PacketProxyUtility {
 
 	private static String OS = System.getProperty("os.name").toLowerCase();
 	private static PacketProxyUtility instance = null;
-	private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
 
 	public static PacketProxyUtility getInstance() {
 		if (instance == null) {
-
 			instance = new PacketProxyUtility();
 		}
 		return instance;
 	}
 
-	private GUILog guiLog;
-
 	public PacketProxyUtility() {
-		guiLog = GUILog.getInstance();
-	}
-
-	public void packetProxyLog(String s) {
-		LocalDateTime now = LocalDateTime.now();
-		String ns = dtf.format(now);
-		String ss = ns + "       " + s;
-		System.out.println(ss);
-		guiLog.append(ss);
-	}
-
-	public void packetProxyLog(String format, Object... args) {
-		packetProxyLog(String.format(format, args));
-	}
-
-	public void packetProxyLogErr(String s) {
-		LocalDateTime now = LocalDateTime.now();
-		String ns = dtf.format(now);
-		String ss = ns + "       " + s;
-		System.err.println(ss);
-		guiLog.appendErr(ss);
-	}
-
-	public void packetProxyLogErr(String format, Object... args) {
-		packetProxyLogErr(String.format(format, args));
-	}
-
-	public void packetProxyLogNewLine() {
-		guiLog.append("\n");
-	}
-
-	public void packetProxyLogErrWithStackTrace(Throwable e) {
-		packetProxyLogErr(e.getMessage());
-		StackTraceElement[] stackTrace = e.getStackTrace();
-		for (int i = 0; i < stackTrace.length; i++) {
-
-			packetProxyLogErr(stackTrace[i].toString());
-		}
 	}
 
 	public byte[] prettyFormatJSONInRawData(byte[] data) {
 		try {
-
 			String str = new String(data, "UTF-8");
 			Stream<String> stream = Arrays.asList(str.split("\r\n\r\n")).stream();
 			return stream.map(this::prettyFormatJSON).filter(j -> !j.isEmpty()).collect(Collectors.joining("\n"))
 					.getBytes();
 		} catch (UnsupportedEncodingException e) {
-
 			e.printStackTrace();
 			return "convert failed".getBytes();
 		}
@@ -98,7 +51,6 @@ public class PacketProxyUtility {
 
 	public String prettyFormatJSON(String data) {
 		try {
-
 			JSONObject tmp_obj;
 			boolean begin_with_left_square_bracket = false; // This variable is true, if json string begin with [
 			int begin = data.length();
@@ -111,18 +63,15 @@ public class PacketProxyUtility {
 			if (data.isEmpty())
 				return "";
 			if (0 == data.indexOf('[')) {
-
 				data = String.format("{data:%s}", data);
 				begin_with_left_square_bracket = true;
 			}
 			tmp_obj = new JSONObject(data);
 			if (begin_with_left_square_bracket) {
-
 				return ((JSONArray) tmp_obj.get("data")).toString(2);
 			}
 			return tmp_obj.toString(2);
 		} catch (Exception e) {
-
 			return "";
 		}
 	}
@@ -142,13 +91,10 @@ public class PacketProxyUtility {
 	public boolean isBinaryData(byte[] data, int defaultSize) {
 		int cnt = 0;
 		for (int i = 0; i < Math.min(data.length, defaultSize); i++) {
-
 			if (data[i] == 0x09 || data[i] == 0x0a || data[i] == 0x0d) {
-
 				continue;
 			}
 			if ((0x00 <= data[i] && data[i] < 0x20) || data[i] == 0x7f) {
-
 				cnt++;
 			}
 		}


### PR DESCRIPTION
ログ出力用のクラスを別に作り、`PacketProxyUtility`クラスから分離しました。また、各クラスでログ関数を直接Importすることで、冗長な呼び出しを短縮しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
