### PR TITLE
VulCheck Helperで生成されるalg=noneのJWTの末尾に.が無いのを修正

### DIFF
--- a/src/main/java/core/packetproxy/common/JWTBase64.java
+++ b/src/main/java/core/packetproxy/common/JWTBase64.java
@@ -37,9 +37,8 @@ public class JWTBase64 extends JWT {
 		sb.append(createPayload(this.payload));
 		String header_payload = sb.toString();
 		String signature = createSignature(header_payload);
+		sb.append(".");
 		if (!signature.isEmpty()) {
-
-			sb.append(".");
 			sb.append(signature);
 		}
 		return sb.toString();


### PR DESCRIPTION
RFCに記載されているalg=noneのJWTの末尾は.になっています。https://datatracker.ietf.org/doc/html/rfc7519#section-6.1
また、node.jsのjsonwebtoken v9.0.2や、golangのgolang-jwt v5.2.2で、末尾に.がないとエラーになることを確認しています。
```js
const jwt = require('jsonwebtoken');
const token = process.argv[2];
try {
  const decoded = jwt.verify(token, null, { algorithms: ['none'] });
  console.log("Claims: ", decoded);
} catch (err) {
  console.error("Error:", err.message);
}
```
```
$ node main.js eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.
Claims:  { sub: '1234567890', name: 'John Doe', admin: true, iat: 1516239022 }

$ node main.js eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0
Error: jwt malformed
```

```go
package main

import (
	"fmt"
	"os"

	"github.com/golang-jwt/jwt/v5"
)

func main() {
	tokenString := os.Args[1]
	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
		return jwt.UnsafeAllowNoneSignatureType, nil
	})
	if err != nil {
		fmt.Printf("Error: %v\n", err)
		return
	}
	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
		fmt.Printf("Claims: %v\n", claims)
	} else {
		fmt.Println("Invalid token")
	}
}
```
```
$ go run main.go eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.
Claims: map[admin:true iat:1.516239022e+09 name:John Doe sub:1234567890]

$ go run main.go eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0
Error: token is malformed: token contains an invalid number of segments
```

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

