### PR TITLE
fix: server encoder was not immediately reflected on change

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIOptionListenPorts.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionListenPorts.java
@@ -26,6 +26,7 @@ import javax.swing.JFrame;
 import packetproxy.model.ListenPort;
 import packetproxy.model.ListenPort.TYPE;
 import packetproxy.model.ListenPorts;
+import packetproxy.model.Servers;
 
 public class GUIOptionListenPorts extends GUIOptionComponentBase<ListenPort> {
 
@@ -37,6 +38,7 @@ public class GUIOptionListenPorts extends GUIOptionComponentBase<ListenPort> {
 		super(owner);
 		listenPorts = ListenPorts.getInstance();
 		listenPorts.addPropertyChangeListener(this);
+		Servers.getInstance().addPropertyChangeListener(this);
 		table_ext_list = new ArrayList<ListenPort>();
 
 		String[] menu = {"Enabled", "Protocol", "Listen Port", "Port Type", "CA", "Forward Server"};
@@ -133,8 +135,7 @@ public class GUIOptionListenPorts extends GUIOptionComponentBase<ListenPort> {
 
 			String serverNullStr = "";
 			TYPE type = listenPort.getType();
-			if (type == TYPE.FORWARDER || type == TYPE.SSL_FORWARDER || type == TYPE.UDP_FORWARDER
-					|| type == TYPE.QUIC_FORWARDER)
+			if (type.isForwarder())
 				serverNullStr = "Deleted";
 			option_model.addRow(new Object[]{listenPort.isEnabled(), listenPort.getProtocol(), listenPort.getPort(),
 					listenPort.getType(), listenPort.getCA().map(ca -> ca.getName()).orElse("Error"),

--- a/src/main/java/core/packetproxy/model/ListenPort.java
+++ b/src/main/java/core/packetproxy/model/ListenPort.java
@@ -27,7 +27,22 @@ public class ListenPort {
 		TCP, UDP
 	}
 	public enum TYPE {
-		HTTP_PROXY, FORWARDER, SSL_FORWARDER, UDP_FORWARDER, SSL_TRANSPARENT_PROXY, HTTP_TRANSPARENT_PROXY, XMPP_SSL_FORWARDER, QUIC_FORWARDER, QUIC_TRANSPARENT_PROXY
+		HTTP_PROXY, FORWARDER, SSL_FORWARDER, UDP_FORWARDER, SSL_TRANSPARENT_PROXY, HTTP_TRANSPARENT_PROXY, XMPP_SSL_FORWARDER, QUIC_FORWARDER, QUIC_TRANSPARENT_PROXY;
+
+		public boolean isForwarder() {
+			return this == FORWARDER || this == SSL_FORWARDER || this == UDP_FORWARDER || this == XMPP_SSL_FORWARDER
+					|| this == QUIC_FORWARDER;
+		}
+
+		public Protocol getProtocol() {
+			if (this == QUIC_FORWARDER || this == QUIC_TRANSPARENT_PROXY || this == UDP_FORWARDER) {
+
+				return Protocol.UDP;
+			} else {
+
+				return Protocol.TCP;
+			}
+		}
 	}
 
 	@DatabaseField(generatedId = true)
@@ -44,16 +59,6 @@ public class ListenPort {
 	private int server_id;
 	private Protocol protocol = null;
 
-	private Protocol getProtocolForPortType(TYPE type) {
-		if (type == TYPE.QUIC_FORWARDER || type == TYPE.QUIC_TRANSPARENT_PROXY || type == TYPE.UDP_FORWARDER) {
-
-			return Protocol.UDP;
-		} else {
-
-			return Protocol.TCP;
-		}
-	}
-
 	public ListenPort() {
 		// ORMLite needs a no-arg constructor
 	}
@@ -64,7 +69,7 @@ public class ListenPort {
 		this.type = type;
 		this.server_id = 0;
 		this.ca_name = "PacketProxy CA";
-		this.protocol = getProtocolForPortType(type);
+		this.protocol = type.getProtocol();
 	}
 
 	public ListenPort(int port, TYPE type, Server server, String ca_name) {
@@ -73,7 +78,7 @@ public class ListenPort {
 		this.type = type;
 		this.server_id = (server != null) ? server.getId() : 0;
 		this.ca_name = ca_name;
-		this.protocol = getProtocolForPortType(type);
+		this.protocol = type.getProtocol();
 	}
 
 	public boolean isEnabled() {
@@ -119,7 +124,7 @@ public class ListenPort {
 	public Protocol getProtocol() {
 		if (this.protocol == null) {
 
-			this.protocol = getProtocolForPortType(this.type);
+			this.protocol = this.type.getProtocol();
 		}
 		return this.protocol;
 	}


### PR DESCRIPTION
サーバのエンコード方式を変更しても、HistoryタブやListen PortsのUI上では古いエンコード方式が表示され続けており、変更後に傍受したパケットも古いエンコード方式で解読されていたため、エンコード方式を変更したら即座にHistoryタブなどでも変更が反映されるようにしました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
