### PR TITLE
Java 25 に対応

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id 'java'
   id 'application'
   id 'eclipse'
-  id 'me.champeau.jmh' version '0.6.6'
+  id 'me.champeau.jmh' version '0.7.3'
   id 'com.bmuschko.izpack' version '3.2'
   id 'com.github.hierynomus.license-report' version "0.16.1"
   id "de.undercouch.download" version "4.0.0"
@@ -26,15 +26,16 @@ repositories {
 
 dependencies {
 
-  compileOnly 'org.projectlombok:lombok:1.18.38'
-  annotationProcessor 'org.projectlombok:lombok:1.18.38'
-  testCompileOnly 'org.projectlombok:lombok:1.18.38'
-  testAnnotationProcessor 'org.projectlombok:lombok:1.18.38'
+  compileOnly 'org.projectlombok:lombok:1.18.42'
+  annotationProcessor 'org.projectlombok:lombok:1.18.42'
+  testCompileOnly 'org.projectlombok:lombok:1.18.42'
+  testAnnotationProcessor 'org.projectlombok:lombok:1.18.42'
 
-  testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter:6.0.0'
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
   testImplementation 'org.assertj:assertj-core:3.23.1'
   testImplementation 'org.mockito:mockito-core:4.7.0'
-  testImplementation 'org.projectlombok:lombok:1.18.34'
+  testImplementation 'org.projectlombok:lombok:1.18.42'
 
   implementation 'com.google.guava:guava:24.1-jre'
   implementation 'commons-codec:commons-codec:1.6'
@@ -133,7 +134,9 @@ spotless {
   }
 }
 
-mainClassName = "packetproxy/PacketProxy"
+application {
+  mainClass = "packetproxy/PacketProxy"
+}
 
 task setVersion {
   project.ext.version = "git describe --tags --abbrev=0".execute().text.replace("\n","")
@@ -274,7 +277,7 @@ jar {
   }
   manifest {
     attributes (
-        "Main-Class": project.mainClassName,
+        "Main-Class": "packetproxy/PacketProxy",
         "Class-Path": configurations.runtimeClasspath.collect { it.getName() }.join(' ')
         )
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 概要
Java 25 でもビルドできるように修正

## ビルドの確認
以下の2つのJavaバージョンにおいてビルドが通ることを確認
```
$ java -version
openjdk version "25" 2025-09-16 LTS
OpenJDK Runtime Environment Corretto-25.0.0.36.2 (build 25+36-LTS)
OpenJDK 64-Bit Server VM Corretto-25.0.0.36.2 (build 25+36-LTS, mixed mode, sharing)
```

```
$ java -version
openjdk version "17.0.15" 2025-04-15 LTS
OpenJDK Runtime Environment Corretto-17.0.15.6.1 (build 17.0.15+6-LTS)
OpenJDK 64-Bit Server VM Corretto-17.0.15.6.1 (build 17.0.15+6-LTS, mixed mode, sharing)
```

## 対応
- [x] 依存関係のアップデート
  - [x] Gradle のアップデート
  - [x] lombok のアップデート
  - [x] jmh のアップデート
  - [x] JUnit のアップデート
  - [x] junit-platform-launcher を導入
- [x] ビルドの確認 (Java 25 / Java 17)

## 規約
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

