### PR TITLE
single packet attack の修正

### DIFF
--- a/src/main/java/core/packetproxy/controller/SinglePacketAttackController.java
+++ b/src/main/java/core/packetproxy/controller/SinglePacketAttackController.java
@@ -120,9 +120,11 @@ public class SinglePacketAttackController {
 		Thread.sleep(sleepTimeMs);
 		sendPing();
 
+		final var allLastFramesData = new ByteArrayOutputStream();
 		for (final var request : requests) {
-			request.sendLastFrames();
+			allLastFramesData.write(request.getLastFramesData());
 		}
+		attackConnection.execFastSend(allLastFramesData.toByteArray());
 
 		for (var i = 0; i < requests.size(); i++) {
 			attackConnection.receive();
@@ -375,10 +377,8 @@ public class SinglePacketAttackController {
 			connection.execFastSend(firstFramesData);
 		}
 
-		private void sendLastFrames() throws Exception {
-			final var lastFramesData = FrameUtils.toByteArray(streamAttackFrames.lastFrames);
-
-			connection.execFastSend(lastFramesData);
+		private byte[] getLastFramesData() throws Exception {
+			return FrameUtils.toByteArray(streamAttackFrames.lastFrames);
 		}
 	}
 }


### PR DESCRIPTION
single packet attack では、各リクエストの最後の1バイトについてのDATAフレームを、1個のTCPパケットにまとめて送信しますが、元々の実装だと複数のTCPパケットに分割されてしまっていました。
DATAフレームを結合してから、`execFastSend`を呼び出すように修正しました。

## 修正前
3個のTCPパケットに分割されてしまっています
<img width="1619" height="498" alt="スクリーンショット 2026-04-02 2 03 27" src="https://github.com/user-attachments/assets/d4b18e12-d9d5-448d-abee-d37abbc777ae" />

## 修正後
1個のTCPパケットにまとまっています
<img width="1619" height="498" alt="スクリーンショット 2026-04-02 2 06 09" src="https://github.com/user-attachments/assets/77da4ef9-9854-4c3c-b9de-ddbf918d0d5c" />

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).