### PR TITLE
fix: Text FrameをBinary Frameとして送信する処理を修正

### DIFF
--- a/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
+++ b/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
@@ -142,7 +142,7 @@ public class EncodeHTTPWebSocket extends Encoder {
 		if (binary_start) {
 
 			byte[] payload = encodeWebsocketResponse(input);
-			WebSocketFrame frame = WebSocketFrame.of(payload, false);
+			WebSocketFrame frame = WebSocketFrame.of(serverWebSocket.lastDequeuedOpCode(), payload, false);
 			return frame.getBytes();
 		} else {
 
@@ -170,7 +170,7 @@ public class EncodeHTTPWebSocket extends Encoder {
 		if (binary_start) {
 
 			byte[] payload = encodeWebsocketRequest(input);
-			WebSocketFrame frame = WebSocketFrame.of(payload, true);
+			WebSocketFrame frame = WebSocketFrame.of(clientWebSocket.lastDequeuedOpCode(), payload, true);
 			return frame.getBytes();
 		} else {
 

--- a/src/main/java/core/packetproxy/websocket/WebSocket.java
+++ b/src/main/java/core/packetproxy/websocket/WebSocket.java
@@ -26,6 +26,12 @@ public class WebSocket {
 
 	LinkedList<WebSocketFrame> frames = new LinkedList<>();
 
+	/**
+	 * Last opcode from {@link #frameAvailable()}; used when re-encoding the payload
+	 * to a wire frame.
+	 */
+	private OpCode lastDequeuedOpCode = OpCode.Binary;
+
 	public static int checkDelimiter(byte[] data) {
 		return WebSocketFrame.checkDelimiter(data);
 	}
@@ -60,6 +66,16 @@ public class WebSocket {
 
 			return null;
 		}
+		this.lastDequeuedOpCode = frame.getOpcode();
 		return frame.getPayload();
+	}
+
+	/**
+	 * Opcode of the frame most recently returned from {@link #frameAvailable()}.
+	 * Encode paths use this to preserve Text vs Binary when rebuilding WebSocket
+	 * frames.
+	 */
+	public OpCode lastDequeuedOpCode() {
+		return lastDequeuedOpCode;
 	}
 }

--- a/src/test/java/packetproxy/encode/EncodeHTTPWebSocketOpCodeTest.java
+++ b/src/test/java/packetproxy/encode/EncodeHTTPWebSocketOpCodeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019,2023 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.encode;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import packetproxy.websocket.OpCode;
+import packetproxy.websocket.WebSocket;
+import packetproxy.websocket.WebSocketFrame;
+
+/**
+ * Ensures Text vs Binary opcode is preserved across decode (frameAvailable) and
+ * encode (getBytes).
+ */
+public class EncodeHTTPWebSocketOpCodeTest {
+
+	private static final byte FIN_TEXT = (byte) 0x81;
+	private static final byte FIN_BINARY = (byte) 0x82;
+
+	/** Unmasked FIN+Text frame, payload "hello". */
+	private static byte[] textFrameHello() {
+		return new byte[]{FIN_TEXT, 0x05, 'h', 'e', 'l', 'l', 'o'};
+	}
+
+	/** Unmasked FIN+Binary frame, single zero byte payload. */
+	private static byte[] binaryFrameOneByte() {
+		return new byte[]{FIN_BINARY, 0x01, 0x00};
+	}
+
+	@Test
+	public void frameAvailableRecordsTextOpcode() throws Exception {
+		WebSocket ws = new WebSocket();
+		ws.frameArrived(textFrameHello());
+		assertArrayEquals("hello".getBytes(StandardCharsets.UTF_8), ws.frameAvailable());
+		assertEquals(OpCode.Text, ws.lastDequeuedOpCode());
+	}
+
+	@Test
+	public void frameAvailableRecordsBinaryOpcode() throws Exception {
+		WebSocket ws = new WebSocket();
+		ws.frameArrived(binaryFrameOneByte());
+		assertArrayEquals(new byte[]{0x00}, ws.frameAvailable());
+		assertEquals(OpCode.Binary, ws.lastDequeuedOpCode());
+	}
+
+	@Test
+	public void encodeClientRequestPreservesTextOpcode() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.clientWebSocket.frameArrived(textFrameHello());
+		byte[] payload = encoder.clientRequestAvailable();
+		byte[] wire = encoder.encodeClientRequest(payload);
+		assertEquals(FIN_TEXT, wire[0]);
+	}
+
+	@Test
+	public void encodeClientRequestPreservesBinaryOpcode() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.clientWebSocket.frameArrived(binaryFrameOneByte());
+		byte[] payload = encoder.clientRequestAvailable();
+		byte[] wire = encoder.encodeClientRequest(payload);
+		assertEquals(FIN_BINARY, wire[0]);
+	}
+
+	@Test
+	public void encodeServerResponsePreservesTextOpcode() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.serverWebSocket.frameArrived(textFrameHello());
+		byte[] payload = encoder.serverResponseAvailable();
+		byte[] wire = encoder.encodeServerResponse(payload);
+		assertEquals(FIN_TEXT, wire[0]);
+	}
+
+	@Test
+	public void parseThenSerializeRoundTripKeepsOpcode() throws Exception {
+		WebSocketFrame text = WebSocketFrame.parse(textFrameHello());
+		assertEquals(OpCode.Text, text.getOpcode());
+		assertArrayEquals(textFrameHello(), WebSocketFrame.of(text.getOpcode(), text.getPayload(), false).getBytes());
+
+		WebSocketFrame bin = WebSocketFrame.parse(binaryFrameOneByte());
+		assertEquals(OpCode.Binary, bin.getOpcode());
+		assertArrayEquals(binaryFrameOneByte(), WebSocketFrame.of(bin.getOpcode(), bin.getPayload(), false).getBytes());
+	}
+
+	private static final class TestEncoder extends EncodeHTTPWebSocket {
+
+		TestEncoder() throws Exception {
+			super();
+		}
+
+		void setBinaryStart(boolean value) {
+			binary_start = value;
+		}
+	}
+}


### PR DESCRIPTION
WebSocket の encode 時に `WebSocketFrame.of(payload, maskEnabled)` を使用しており、OpCode を常にBinary Frame としてハードコードしていました。
そのため、Text Frame を受信しても Binary Frame として再送信されていました。

- `WebSocket.frameAvailable()` で dequeue 時にフレームの OpCode を記録するようにしました
- `EncodeHTTPWebSocket.encodeServerResponse()` / `encodeClientRequest()` で
  記録した OpCode を `WebSocketFrame.of(opcode, payload, maskEnabled)` に渡すように修正しました

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

