### PR TITLE
fix: WebSocketのペイロードが0の場合に受信したパケットを送信しない問題を修正

### DIFF
--- a/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
+++ b/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
@@ -31,10 +31,6 @@ public class EncodeHTTPWebSocket extends Encoder {
 	 */
 	static final byte[] EMPTY_PAYLOAD_PLACEHOLDER = "(empty WebSocket frame)".getBytes(StandardCharsets.UTF_8);
 
-	private static boolean isEmptyPlaceholder(byte[] data) {
-		return Arrays.equals(data, EMPTY_PAYLOAD_PLACEHOLDER);
-	}
-
 	protected boolean binary_start = false;
 	WebSocket clientWebSocket = new WebSocket();
 	WebSocket serverWebSocket = new WebSocket();
@@ -169,7 +165,7 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] encodeServerResponse(byte[] input) throws Exception {
 		if (binary_start) {
 
-			boolean emptyPlaceholder = isEmptyPlaceholder(input);
+			boolean emptyPlaceholder = Arrays.equals(input, EMPTY_PAYLOAD_PLACEHOLDER);
 			byte[] payload = emptyPlaceholder ? new byte[0] : encodeWebsocketResponse(input);
 			WebSocketFrame frame = WebSocketFrame.of(serverWebSocket.lastDequeuedOpCode(), payload, false);
 			return frame.getBytes();
@@ -200,7 +196,7 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] encodeClientRequest(byte[] input) throws Exception {
 		if (binary_start) {
 
-			boolean emptyPlaceholder = isEmptyPlaceholder(input);
+			boolean emptyPlaceholder = Arrays.equals(input, EMPTY_PAYLOAD_PLACEHOLDER);
 			byte[] payload = emptyPlaceholder ? new byte[0] : encodeWebsocketRequest(input);
 			WebSocketFrame frame = WebSocketFrame.of(clientWebSocket.lastDequeuedOpCode(), payload, true);
 			return frame.getBytes();

--- a/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
+++ b/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
@@ -31,6 +31,18 @@ public class EncodeHTTPWebSocket extends Encoder {
 	 */
 	static final byte[] EMPTY_PAYLOAD_PLACEHOLDER = "(empty WebSocket frame)".getBytes(StandardCharsets.UTF_8);
 
+	/**
+	 * Set when {@link #clientRequestAvailable()} replaced a zero-length payload
+	 * with {@link #EMPTY_PAYLOAD_PLACEHOLDER}.
+	 */
+	private boolean clientEmptyPayloadFlag = false;
+
+	/**
+	 * Set when {@link #serverResponseAvailable()} replaced a zero-length payload
+	 * with {@link #EMPTY_PAYLOAD_PLACEHOLDER}.
+	 */
+	private boolean serverEmptyPayloadFlag = false;
+
 	protected boolean binary_start = false;
 	WebSocket clientWebSocket = new WebSocket();
 	WebSocket serverWebSocket = new WebSocket();
@@ -123,6 +135,7 @@ public class EncodeHTTPWebSocket extends Encoder {
 			// Map empty WebSocket payload to the placeholder so the duplex pipeline runs
 			// decode/intercept/send.
 			if (payload != null && payload.length == 0) {
+				clientEmptyPayloadFlag = true;
 				return EMPTY_PAYLOAD_PLACEHOLDER;
 			}
 			return payload;
@@ -138,6 +151,7 @@ public class EncodeHTTPWebSocket extends Encoder {
 
 			byte[] payload = serverWebSocket.frameAvailable();
 			if (payload != null && payload.length == 0) {
+				serverEmptyPayloadFlag = true;
 				return EMPTY_PAYLOAD_PLACEHOLDER;
 			}
 			return payload;
@@ -165,8 +179,15 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] encodeServerResponse(byte[] input) throws Exception {
 		if (binary_start) {
 
-			boolean emptyPlaceholder = Arrays.equals(input, EMPTY_PAYLOAD_PLACEHOLDER);
-			byte[] payload = emptyPlaceholder ? new byte[0] : encodeWebsocketResponse(input);
+			byte[] payload;
+			if (serverEmptyPayloadFlag) {
+				serverEmptyPayloadFlag = false;
+				payload = Arrays.equals(input, EMPTY_PAYLOAD_PLACEHOLDER)
+						? new byte[0]
+						: encodeWebsocketResponse(input);
+			} else {
+				payload = encodeWebsocketResponse(input);
+			}
 			WebSocketFrame frame = WebSocketFrame.of(serverWebSocket.lastDequeuedOpCode(), payload, false);
 			return frame.getBytes();
 		} else {
@@ -196,8 +217,13 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] encodeClientRequest(byte[] input) throws Exception {
 		if (binary_start) {
 
-			boolean emptyPlaceholder = Arrays.equals(input, EMPTY_PAYLOAD_PLACEHOLDER);
-			byte[] payload = emptyPlaceholder ? new byte[0] : encodeWebsocketRequest(input);
+			byte[] payload;
+			if (clientEmptyPayloadFlag) {
+				clientEmptyPayloadFlag = false;
+				payload = Arrays.equals(input, EMPTY_PAYLOAD_PLACEHOLDER) ? new byte[0] : encodeWebsocketRequest(input);
+			} else {
+				payload = encodeWebsocketRequest(input);
+			}
 			WebSocketFrame frame = WebSocketFrame.of(clientWebSocket.lastDequeuedOpCode(), payload, true);
 			return frame.getBytes();
 		} else {

--- a/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
+++ b/src/main/java/core/packetproxy/encode/EncodeHTTPWebSocket.java
@@ -15,11 +15,25 @@
  */
 package packetproxy.encode;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import packetproxy.http.Http;
 import packetproxy.websocket.WebSocket;
 import packetproxy.websocket.WebSocketFrame;
 
 public class EncodeHTTPWebSocket extends Encoder {
+
+	/**
+	 * Sentinel shown in History/Intercept for empty-payload WebSocket frames.
+	 * Encode path restores this to a zero-length payload so the wire frame stays
+	 * spec-compliant. If the user replaces this text in Intercept, the edited bytes
+	 * are sent as the actual payload.
+	 */
+	static final byte[] EMPTY_PAYLOAD_PLACEHOLDER = "(empty WebSocket frame)".getBytes(StandardCharsets.UTF_8);
+
+	private static boolean isEmptyPlaceholder(byte[] data) {
+		return Arrays.equals(data, EMPTY_PAYLOAD_PLACEHOLDER);
+	}
 
 	protected boolean binary_start = false;
 	WebSocket clientWebSocket = new WebSocket();
@@ -107,7 +121,15 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] clientRequestAvailable() throws Exception {
 		if (binary_start) {
 
-			return clientWebSocket.frameAvailable();
+			byte[] payload = clientWebSocket.frameAvailable();
+			// Simplex treats byte[0] from clientRequestAvailable as "no more chunks" (same
+			// as Encoder base).
+			// Map empty WebSocket payload to the placeholder so the duplex pipeline runs
+			// decode/intercept/send.
+			if (payload != null && payload.length == 0) {
+				return EMPTY_PAYLOAD_PLACEHOLDER;
+			}
+			return payload;
 		} else {
 
 			return super.clientRequestAvailable();
@@ -118,7 +140,11 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] serverResponseAvailable() throws Exception {
 		if (binary_start) {
 
-			return serverWebSocket.frameAvailable();
+			byte[] payload = serverWebSocket.frameAvailable();
+			if (payload != null && payload.length == 0) {
+				return EMPTY_PAYLOAD_PLACEHOLDER;
+			}
+			return payload;
 		} else {
 
 			return super.serverResponseAvailable();
@@ -128,7 +154,9 @@ public class EncodeHTTPWebSocket extends Encoder {
 	@Override
 	public byte[] decodeServerResponse(byte[] input) throws Exception {
 		if (binary_start) {
-
+			if (input.length == 0) {
+				return EMPTY_PAYLOAD_PLACEHOLDER;
+			}
 			return decodeWebsocketResponse(input);
 		} else {
 
@@ -141,7 +169,8 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] encodeServerResponse(byte[] input) throws Exception {
 		if (binary_start) {
 
-			byte[] payload = encodeWebsocketResponse(input);
+			boolean emptyPlaceholder = isEmptyPlaceholder(input);
+			byte[] payload = emptyPlaceholder ? new byte[0] : encodeWebsocketResponse(input);
 			WebSocketFrame frame = WebSocketFrame.of(serverWebSocket.lastDequeuedOpCode(), payload, false);
 			return frame.getBytes();
 		} else {
@@ -156,7 +185,9 @@ public class EncodeHTTPWebSocket extends Encoder {
 	@Override
 	public byte[] decodeClientRequest(byte[] input) throws Exception {
 		if (binary_start) {
-
+			if (input.length == 0) {
+				return EMPTY_PAYLOAD_PLACEHOLDER;
+			}
 			return decodeWebsocketRequest(input);
 		} else {
 
@@ -169,7 +200,8 @@ public class EncodeHTTPWebSocket extends Encoder {
 	public byte[] encodeClientRequest(byte[] input) throws Exception {
 		if (binary_start) {
 
-			byte[] payload = encodeWebsocketRequest(input);
+			boolean emptyPlaceholder = isEmptyPlaceholder(input);
+			byte[] payload = emptyPlaceholder ? new byte[0] : encodeWebsocketRequest(input);
 			WebSocketFrame frame = WebSocketFrame.of(clientWebSocket.lastDequeuedOpCode(), payload, true);
 			return frame.getBytes();
 		} else {

--- a/src/test/java/packetproxy/encode/EncodeHTTPWebSocketOpCodeTest.java
+++ b/src/test/java/packetproxy/encode/EncodeHTTPWebSocketOpCodeTest.java
@@ -17,6 +17,7 @@ package packetproxy.encode;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.charset.StandardCharsets;
@@ -26,23 +27,51 @@ import packetproxy.websocket.WebSocket;
 import packetproxy.websocket.WebSocketFrame;
 
 /**
- * Tests that:
- * 1. Text vs Binary opcode is preserved across decode/encode.
- * 2. Empty-payload WebSocket frames flow through the pipeline.
+ * Tests that: 1. Text vs Binary opcode is preserved across decode/encode. 2.
+ * Empty-payload WebSocket frames flow through the pipeline.
  */
 public class EncodeHTTPWebSocketOpCodeTest {
 
-	private static final byte FIN_TEXT = (byte) 0x81;
-	private static final byte FIN_BINARY = (byte) 0x82;
+	/** RFC 6455 frame byte 0: FIN (bit 7). */
+	private static final int WS_FIN_BIT = 0x80;
+
+	/** RFC 6455 frame byte 1: MASK (bit 7) for client-to-server frames. */
+	private static final int WS_MASK_BIT = 0x80;
+
+	/**
+	 * RFC 6455 frame byte 1: bits 0–6 — payload length when that value is 0–125.
+	 */
+	private static final int WS_PAYLOAD_LEN_7BIT_MASK = 0x7F;
+
+	private static byte finFirstByte(OpCode opcode) {
+		return (byte) (WS_FIN_BIT | (opcode.code & 0x0F));
+	}
+
+	private static byte unmaskedPayloadLenByte(int payloadLength) {
+		return (byte) (payloadLength & WS_PAYLOAD_LEN_7BIT_MASK);
+	}
+
+	private static byte maskedPayloadLenByte(int payloadLength) {
+		return (byte) (WS_MASK_BIT | (payloadLength & WS_PAYLOAD_LEN_7BIT_MASK));
+	}
+
+	private static int payloadLen7Bits(byte secondByte) {
+		return secondByte & WS_PAYLOAD_LEN_7BIT_MASK;
+	}
 
 	/** Unmasked FIN+Text frame, payload "hello". */
 	private static byte[] textFrameHello() {
-		return new byte[]{FIN_TEXT, 0x05, 'h', 'e', 'l', 'l', 'o'};
+		byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+		byte[] frame = new byte[2 + payload.length];
+		frame[0] = finFirstByte(OpCode.Text);
+		frame[1] = unmaskedPayloadLenByte(payload.length);
+		System.arraycopy(payload, 0, frame, 2, payload.length);
+		return frame;
 	}
 
 	/** Unmasked FIN+Binary frame, single zero byte payload. */
 	private static byte[] binaryFrameOneByte() {
-		return new byte[]{FIN_BINARY, 0x01, 0x00};
+		return new byte[]{finFirstByte(OpCode.Binary), unmaskedPayloadLenByte(1), 0x00};
 	}
 
 	@Test
@@ -68,7 +97,7 @@ public class EncodeHTTPWebSocketOpCodeTest {
 		encoder.clientWebSocket.frameArrived(textFrameHello());
 		byte[] payload = encoder.clientRequestAvailable();
 		byte[] wire = encoder.encodeClientRequest(payload);
-		assertEquals(FIN_TEXT, wire[0]);
+		assertEquals(finFirstByte(OpCode.Text), wire[0]);
 	}
 
 	@Test
@@ -78,7 +107,7 @@ public class EncodeHTTPWebSocketOpCodeTest {
 		encoder.clientWebSocket.frameArrived(binaryFrameOneByte());
 		byte[] payload = encoder.clientRequestAvailable();
 		byte[] wire = encoder.encodeClientRequest(payload);
-		assertEquals(FIN_BINARY, wire[0]);
+		assertEquals(finFirstByte(OpCode.Binary), wire[0]);
 	}
 
 	@Test
@@ -88,7 +117,7 @@ public class EncodeHTTPWebSocketOpCodeTest {
 		encoder.serverWebSocket.frameArrived(textFrameHello());
 		byte[] payload = encoder.serverResponseAvailable();
 		byte[] wire = encoder.encodeServerResponse(payload);
-		assertEquals(FIN_TEXT, wire[0]);
+		assertEquals(finFirstByte(OpCode.Text), wire[0]);
 	}
 
 	@Test
@@ -104,12 +133,12 @@ public class EncodeHTTPWebSocketOpCodeTest {
 
 	/** Unmasked FIN+Text frame, zero-length payload. */
 	private static byte[] textFrameEmptyPayload() {
-		return new byte[]{FIN_TEXT, 0x00};
+		return new byte[]{finFirstByte(OpCode.Text), unmaskedPayloadLenByte(0)};
 	}
 
 	/** Unmasked FIN+Binary frame, zero-length payload. */
 	private static byte[] binaryFrameEmptyPayload() {
-		return new byte[]{FIN_BINARY, 0x00};
+		return new byte[]{finFirstByte(OpCode.Binary), unmaskedPayloadLenByte(0)};
 	}
 
 	@Test
@@ -156,8 +185,8 @@ public class EncodeHTTPWebSocketOpCodeTest {
 		byte[] decoded = encoder.decodeClientRequest(payload);
 		byte[] wire = encoder.encodeClientRequest(decoded);
 		// lastDequeuedOpCode preserves Text from the original frame
-		assertEquals(FIN_TEXT, wire[0]);
-		assertEquals(0, wire[1] & 0x7F);
+		assertEquals(finFirstByte(OpCode.Text), wire[0]);
+		assertEquals(0, payloadLen7Bits(wire[1]));
 	}
 
 	@Test
@@ -184,8 +213,36 @@ public class EncodeHTTPWebSocketOpCodeTest {
 		byte[] userEdited = "hello".getBytes(StandardCharsets.UTF_8);
 		byte[] wire = encoder.encodeClientRequest(userEdited);
 		// lastDequeuedOpCode preserves Text from the original frame
-		assertEquals(FIN_TEXT, wire[0]);
-		assertEquals((byte) (0x80 | 5), wire[1]);
+		assertEquals(finFirstByte(OpCode.Text), wire[0]);
+		assertEquals(maskedPayloadLenByte(userEdited.length), wire[1]);
+	}
+
+	/**
+	 * If the literal placeholder bytes are sent as payload without having come from
+	 * an empty frame, encode must not collapse them to a zero-length payload.
+	 */
+	@Test
+	public void placeholderPayloadWithoutEmptyFrameFlagIsNotCollapsedToEmpty() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.clientWebSocket.frameArrived(textFrameHello());
+		encoder.clientWebSocket.passThroughFrame();
+		encoder.clientRequestAvailable();
+		byte[] wire = encoder.encodeClientRequest(EncodeHTTPWebSocket.EMPTY_PAYLOAD_PLACEHOLDER);
+		assertEquals(finFirstByte(OpCode.Text), wire[0]);
+		assertNotEquals(0, payloadLen7Bits(wire[1]));
+	}
+
+	@Test
+	public void placeholderServerPayloadWithoutEmptyFrameFlagIsNotCollapsedToEmpty() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.serverWebSocket.frameArrived(textFrameHello());
+		encoder.serverWebSocket.passThroughFrame();
+		encoder.serverResponseAvailable();
+		byte[] wire = encoder.encodeServerResponse(EncodeHTTPWebSocket.EMPTY_PAYLOAD_PLACEHOLDER);
+		assertEquals(finFirstByte(OpCode.Text), wire[0]);
+		assertEquals(EncodeHTTPWebSocket.EMPTY_PAYLOAD_PLACEHOLDER.length, payloadLen7Bits(wire[1]));
 	}
 
 	private static final class TestEncoder extends EncodeHTTPWebSocket {

--- a/src/test/java/packetproxy/encode/EncodeHTTPWebSocketOpCodeTest.java
+++ b/src/test/java/packetproxy/encode/EncodeHTTPWebSocketOpCodeTest.java
@@ -17,6 +17,7 @@ package packetproxy.encode;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -25,8 +26,9 @@ import packetproxy.websocket.WebSocket;
 import packetproxy.websocket.WebSocketFrame;
 
 /**
- * Ensures Text vs Binary opcode is preserved across decode (frameAvailable) and
- * encode (getBytes).
+ * Tests that:
+ * 1. Text vs Binary opcode is preserved across decode/encode.
+ * 2. Empty-payload WebSocket frames flow through the pipeline.
  */
 public class EncodeHTTPWebSocketOpCodeTest {
 
@@ -98,6 +100,92 @@ public class EncodeHTTPWebSocketOpCodeTest {
 		WebSocketFrame bin = WebSocketFrame.parse(binaryFrameOneByte());
 		assertEquals(OpCode.Binary, bin.getOpcode());
 		assertArrayEquals(binaryFrameOneByte(), WebSocketFrame.of(bin.getOpcode(), bin.getPayload(), false).getBytes());
+	}
+
+	/** Unmasked FIN+Text frame, zero-length payload. */
+	private static byte[] textFrameEmptyPayload() {
+		return new byte[]{FIN_TEXT, 0x00};
+	}
+
+	/** Unmasked FIN+Binary frame, zero-length payload. */
+	private static byte[] binaryFrameEmptyPayload() {
+		return new byte[]{FIN_BINARY, 0x00};
+	}
+
+	@Test
+	public void emptyPayloadTextFrameQueuesForDecode() throws Exception {
+		WebSocket ws = new WebSocket();
+		ws.frameArrived(textFrameEmptyPayload());
+		assertArrayEquals(new byte[0], ws.passThroughFrame());
+		assertArrayEquals(new byte[0], ws.frameAvailable());
+	}
+
+	@Test
+	public void emptyPayloadBinaryFrameQueuesForDecode() throws Exception {
+		WebSocket ws = new WebSocket();
+		ws.frameArrived(binaryFrameEmptyPayload());
+		assertArrayEquals(new byte[0], ws.passThroughFrame());
+		assertArrayEquals(new byte[0], ws.frameAvailable());
+	}
+
+	@Test
+	public void decodeClientRequestReturnsPlaceholderForEmptyPayload() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		byte[] decoded = encoder.decodeClientRequest(new byte[0]);
+		assertArrayEquals(EncodeHTTPWebSocket.EMPTY_PAYLOAD_PLACEHOLDER, decoded);
+	}
+
+	@Test
+	public void decodeServerResponseReturnsPlaceholderForEmptyPayload() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		byte[] decoded = encoder.decodeServerResponse(new byte[0]);
+		assertArrayEquals(EncodeHTTPWebSocket.EMPTY_PAYLOAD_PLACEHOLDER, decoded);
+	}
+
+	@Test
+	public void emptyPayloadClientRequestRoundTrip() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.clientWebSocket.frameArrived(textFrameEmptyPayload());
+		encoder.clientWebSocket.passThroughFrame();
+		byte[] payload = encoder.clientRequestAvailable();
+		assertNotNull(payload);
+		assertArrayEquals(EncodeHTTPWebSocket.EMPTY_PAYLOAD_PLACEHOLDER, payload);
+		byte[] decoded = encoder.decodeClientRequest(payload);
+		byte[] wire = encoder.encodeClientRequest(decoded);
+		// lastDequeuedOpCode preserves Text from the original frame
+		assertEquals(FIN_TEXT, wire[0]);
+		assertEquals(0, wire[1] & 0x7F);
+	}
+
+	@Test
+	public void emptyPayloadServerResponseRoundTrip() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.serverWebSocket.frameArrived(binaryFrameEmptyPayload());
+		encoder.serverWebSocket.passThroughFrame();
+		byte[] payload = encoder.serverResponseAvailable();
+		assertNotNull(payload);
+		assertArrayEquals(EncodeHTTPWebSocket.EMPTY_PAYLOAD_PLACEHOLDER, payload);
+		byte[] decoded = encoder.decodeServerResponse(payload);
+		byte[] wire = encoder.encodeServerResponse(decoded);
+		assertArrayEquals(binaryFrameEmptyPayload(), wire);
+	}
+
+	@Test
+	public void editedPlaceholderClientRequestSendsNewContent() throws Exception {
+		TestEncoder encoder = new TestEncoder();
+		encoder.setBinaryStart(true);
+		encoder.clientWebSocket.frameArrived(textFrameEmptyPayload());
+		encoder.clientWebSocket.passThroughFrame();
+		encoder.clientRequestAvailable();
+		byte[] userEdited = "hello".getBytes(StandardCharsets.UTF_8);
+		byte[] wire = encoder.encodeClientRequest(userEdited);
+		// lastDequeuedOpCode preserves Text from the original frame
+		assertEquals(FIN_TEXT, wire[0]);
+		assertEquals((byte) (0x80 | 5), wire[1]);
 	}
 
 	private static final class TestEncoder extends EncodeHTTPWebSocket {


### PR DESCRIPTION
ペイロード長が0のWebSocketフレームをPacketProxyが受信後に送信していなかったので修正しました。

Simplexのメインループは `callOnChunkAvailable()` の戻り値が `null` または`length == 0` のときにループを終了する設計になっています。
WebSocketのペイロード長0のフレームを受信すると、パケットがドロップされていました。

https://github.com/DeNA/PacketProxy/blob/9ccfa2e19f2af65a967dd9206744ad850722f939/src/main/java/core/packetproxy/Simplex.java#L256-L257


修正がEncodeHTTPWebSocket 内で完結するように、空のペイロードはプレースホルダーで置換して表示するようにしました。
空ペイロードを `(empty WebSocket frame)` に置換して通過させ、encode時にゼロバイトに戻しています。
- 受信/デコード時: 空ペイロードを `(empty WebSocket frame)` に置換
- 送信/エンコード時: プレースホルダーを `byte[0]` に復元
- Intercept対応: ユーザーがプレースホルダーを別のテキストに編集した場合、その内容がそのまま送信されます

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

