### PR TITLE
fix: Diff画面でデータが表示されない問題を修正

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIData.java
+++ b/src/main/java/core/packetproxy/gui/GUIData.java
@@ -571,7 +571,7 @@ public class GUIData {
 	 */
 	private byte[] resolveDataForDiff() throws Exception {
 		if (!GUIHistory.getInstance().isSelectedRowMerged()) {
-			return tabs.getRaw().getData();
+			return getActiveData();
 		}
 		// macOS の JOptionPane はボタンを右から左に描画するため、
 		// 視覚的に左から「Request | Response」の順にするには逆順で定義する。
@@ -581,7 +581,7 @@ public class GUIData {
 		if (choice == JOptionPane.CLOSED_OPTION)
 			return null;
 		if (choice == 0)
-			return GUIPacket.getInstance().getResponsePacket().getReceivedData();
-		return tabs.getRaw().getData();
+			return responseDataProvider != null ? responseDataProvider.get() : null;
+		return getActiveData();
 	}
 }


### PR DESCRIPTION
Diff機能（mark as orig / diff!!）で、Requestのデータが空になり何も表示されない問題を修正しました

resolveDataForDiff() が Raw サブタブを直接参照していたため、Received Packet タブにデータが載らない場合に空になる問題を修正しました。
 getActiveData() / responseDataProvider 経由でデータを取得するように統一しました。


- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

