### PR TITLE
fix: preserve log copy formatting

### DIFF
--- a/src/main/java/core/packetproxy/gui/ExtendedTextPane.java
+++ b/src/main/java/core/packetproxy/gui/ExtendedTextPane.java
@@ -23,7 +23,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.Arrays;
 import java.util.EventListener;
-import javax.swing.JTextPane;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.EventListenerList;
@@ -38,7 +37,7 @@ import packetproxy.common.Utils;
 import packetproxy.util.CharSetUtility;
 import packetproxy.util.PacketProxyUtility;
 
-abstract class ExtendedTextPane extends JTextPane {
+abstract class ExtendedTextPane extends PlainTextCopyTextPane {
 
 	private static final long serialVersionUID = 3879881178060039018L;
 	private static final int TEXT_TRIMMING_SIZE = 300000;

--- a/src/main/java/core/packetproxy/gui/GUILog.java
+++ b/src/main/java/core/packetproxy/gui/GUILog.java
@@ -34,7 +34,7 @@ public class GUILog {
 	private Object thread_lock;
 
 	public GUILog() {
-		text = new JTextPane();
+		text = new PlainTextCopyTextPane();
 		text.setEditable(false);
 		scrollPane = new JScrollPane(text);
 		scrollPane.getVerticalScrollBar().setUnitIncrement(16);

--- a/src/main/java/core/packetproxy/gui/PlainTextCopyTextPane.java
+++ b/src/main/java/core/packetproxy/gui/PlainTextCopyTextPane.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.gui;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.StringSelection;
+import javax.swing.JTextPane;
+
+class PlainTextCopyTextPane extends JTextPane {
+
+	@Override
+	public void copy() {
+		var selected = getSelectedText();
+		if (selected == null || selected.isEmpty()) {
+			super.copy();
+			return;
+		}
+
+		var clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+		var selection = new StringSelection(prepareTextForCopy(selected));
+		clipboard.setContents(selection, selection);
+	}
+
+	protected String prepareTextForCopy(String selected) {
+		return selected;
+	}
+}

--- a/src/main/java/core/packetproxy/gui/RawTextPane.java
+++ b/src/main/java/core/packetproxy/gui/RawTextPane.java
@@ -19,8 +19,6 @@ import static packetproxy.util.Logging.errWithStackTrace;
 
 import java.awt.Color;
 import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
@@ -403,17 +401,8 @@ public class RawTextPane extends ExtendedTextPane {
 	}
 
 	@Override
-	public void copy() {
-		String selected = getSelectedText();
-		if (selected == null || selected.isEmpty()) {
-			super.copy();
-			return;
-		}
-
-		String sanitized = stripTrailingNewlines(selected);
-		Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-		StringSelection selection = new StringSelection(sanitized);
-		clipboard.setContents(selection, selection);
+	protected String prepareTextForCopy(String selected) {
+		return stripTrailingNewlines(selected);
 	}
 
 	@Override


### PR DESCRIPTION
Logタブからログをコピーすると、各行ごとに空行が挿入されたり、先頭のインデントが削除されたりしていたので、修正しました。
他のテキストフィールドでも同様の処理がされているため、 `copy` メソッドをオーバーライドしたクラスを別に作成し、それぞれがそれを継承するようにしました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

