### PR TITLE
refactor(common): decouple ConfigHttpServer from Swing dialogs

### DIFF
--- a/src/main/java/core/packetproxy/common/ConfigHttpServer.java
+++ b/src/main/java/core/packetproxy/common/ConfigHttpServer.java
@@ -6,17 +6,20 @@ import fi.iki.elonen.NanoHTTPD;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.*;
-import packetproxy.gui.GUIMain;
 import packetproxy.model.*;
 
 public class ConfigHttpServer extends NanoHTTPD {
 
 	private final String allowedAccessToken;
+	private final ConfigHttpUiActions uiActions;
+	private final ConfigSettingsWriter settingsWriter;
 
-	public ConfigHttpServer(String hostname, int port, String allowedAccessToken) {
+	public ConfigHttpServer(String hostname, int port, String allowedAccessToken, ConfigHttpUiActions uiActions,
+			ConfigSettingsWriter settingsWriter) {
 		super(hostname, port);
 		this.allowedAccessToken = allowedAccessToken;
+		this.uiActions = uiActions;
+		this.settingsWriter = settingsWriter;
 	}
 
 	private void fixUpServerList(Map<Integer, Integer> serverMap, List<Server> serverList) {
@@ -117,18 +120,9 @@ public class ConfigHttpServer extends NanoHTTPD {
 
 			try {
 
-				GUIMain.getInstance().setAlwaysOnTop(true);
-				GUIMain.getInstance().setVisible(true);
+				uiActions.showOptionsTab();
 
-				GUIMain.getInstance().getTabbedPane().setSelectedIndex(GUIMain.Panes.OPTIONS.ordinal());
-
-				int option = JOptionPane.showConfirmDialog(GUIMain.getInstance(),
-						I18nString.get("Do you want to overwrite config?"), I18nString.get("Loading config"),
-						JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-
-				GUIMain.getInstance().setAlwaysOnTop(false);
-
-				if (option == JOptionPane.NO_OPTION) {
+				if (!uiActions.confirmOverwriteConfig()) {
 
 					return NanoHTTPD.newFixedLengthResponse(Response.Status.UNAUTHORIZED, MIME_HTML, null);
 				}
@@ -137,26 +131,7 @@ public class ConfigHttpServer extends NanoHTTPD {
 				session.parseBody(map);
 				String json = map.get("postData");
 
-				ConfigDaoHub daoHub = new Gson().fromJson(json, ConfigDaoHub.class);
-
-				Database.getInstance().dropConfigs();
-
-				for (ListenPort listenPort : daoHub.listenPortList) {
-
-					ListenPorts.getInstance().create(listenPort);
-				}
-				for (Server server : daoHub.serverList) {
-
-					Servers.getInstance().create(server);
-				}
-				for (Modification mod : daoHub.modificationList) {
-
-					Modifications.getInstance().create(mod);
-				}
-				for (SSLPassThrough passThrough : daoHub.sslPassThroughList) {
-
-					SSLPassThroughs.getInstance().create(passThrough);
-				}
+				settingsWriter.applyFromJson(json);
 
 				Response res = NanoHTTPD.newFixedLengthResponse(Response.Status.OK, "application/json",
 						"{\"status\": \"ok\"}");

--- a/src/main/java/core/packetproxy/common/ConfigHttpUiActions.java
+++ b/src/main/java/core/packetproxy/common/ConfigHttpUiActions.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package packetproxy.common;
 
 /** リモート設定 HTTP API から必要な GUI 操作。 */

--- a/src/main/java/core/packetproxy/common/ConfigHttpUiActions.java
+++ b/src/main/java/core/packetproxy/common/ConfigHttpUiActions.java
@@ -1,0 +1,12 @@
+package packetproxy.common;
+
+/** リモート設定 HTTP API から必要な GUI 操作。 */
+public interface ConfigHttpUiActions {
+
+	void showOptionsTab();
+
+	/**
+	 * @return 設定上書きを許可する場合 true
+	 */
+	boolean confirmOverwriteConfig();
+}

--- a/src/main/java/core/packetproxy/common/ConfigSettingsWriter.java
+++ b/src/main/java/core/packetproxy/common/ConfigSettingsWriter.java
@@ -16,30 +16,13 @@
 package packetproxy.common;
 
 import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
-import java.util.List;
 import packetproxy.model.*;
 
 /** リモート設定 JSON を DB に反映する。 */
 public class ConfigSettingsWriter {
 
-	private static class DaoHub {
-
-		@SerializedName(value = "listenPorts")
-		List<ListenPort> listenPortList;
-
-		@SerializedName(value = "servers")
-		List<Server> serverList;
-
-		@SerializedName(value = "modifications")
-		List<Modification> modificationList;
-
-		@SerializedName(value = "sslPassThroughs")
-		List<SSLPassThrough> sslPassThroughList;
-	}
-
 	public void applyFromJson(String json) throws Exception {
-		var daoHub = new Gson().fromJson(json, DaoHub.class);
+		var daoHub = new Gson().fromJson(json, ConfigDaoHub.class);
 
 		Database.getInstance().dropConfigs();
 

--- a/src/main/java/core/packetproxy/common/ConfigSettingsWriter.java
+++ b/src/main/java/core/packetproxy/common/ConfigSettingsWriter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package packetproxy.common;
 
 import com.google.gson.Gson;

--- a/src/main/java/core/packetproxy/common/ConfigSettingsWriter.java
+++ b/src/main/java/core/packetproxy/common/ConfigSettingsWriter.java
@@ -1,0 +1,48 @@
+package packetproxy.common;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+import packetproxy.model.*;
+
+/** リモート設定 JSON を DB に反映する。 */
+public class ConfigSettingsWriter {
+
+	private static class DaoHub {
+
+		@SerializedName(value = "listenPorts")
+		List<ListenPort> listenPortList;
+
+		@SerializedName(value = "servers")
+		List<Server> serverList;
+
+		@SerializedName(value = "modifications")
+		List<Modification> modificationList;
+
+		@SerializedName(value = "sslPassThroughs")
+		List<SSLPassThrough> sslPassThroughList;
+	}
+
+	public void applyFromJson(String json) throws Exception {
+		var daoHub = new Gson().fromJson(json, DaoHub.class);
+
+		Database.getInstance().dropConfigs();
+
+		for (ListenPort listenPort : daoHub.listenPortList) {
+
+			ListenPorts.getInstance().create(listenPort);
+		}
+		for (Server server : daoHub.serverList) {
+
+			Servers.getInstance().create(server);
+		}
+		for (Modification mod : daoHub.modificationList) {
+
+			Modifications.getInstance().create(mod);
+		}
+		for (SSLPassThrough passThrough : daoHub.sslPassThroughList) {
+
+			SSLPassThroughs.getInstance().create(passThrough);
+		}
+	}
+}

--- a/src/main/java/core/packetproxy/gui/GUIOptionHubServer.java
+++ b/src/main/java/core/packetproxy/gui/GUIOptionHubServer.java
@@ -11,6 +11,7 @@ import java.beans.PropertyChangeListener;
 import javax.swing.*;
 import org.apache.commons.lang3.RandomStringUtils;
 import packetproxy.common.ConfigHttpServer;
+import packetproxy.common.ConfigSettingsWriter;
 import packetproxy.common.I18nString;
 import packetproxy.model.ConfigBoolean;
 import packetproxy.model.ConfigString;
@@ -104,7 +105,8 @@ public class GUIOptionHubServer implements PropertyChangeListener {
 
 	private void startServer() throws Exception {
 		String accessToken = new ConfigString("SharingConfigsAccessToken").getString();
-		this.server = new ConfigHttpServer("localhost", 32349, accessToken);
+		this.server = new ConfigHttpServer("localhost", 32349, accessToken, new SwingConfigHttpUiActions(),
+				new ConfigSettingsWriter());
 		this.server.start();
 	}
 

--- a/src/main/java/core/packetproxy/gui/SwingConfigHttpUiActions.java
+++ b/src/main/java/core/packetproxy/gui/SwingConfigHttpUiActions.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 DeNA Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package packetproxy.gui;
+
+import javax.swing.JOptionPane;
+import packetproxy.common.ConfigHttpUiActions;
+import packetproxy.common.I18nString;
+
+public class SwingConfigHttpUiActions implements ConfigHttpUiActions {
+
+	@Override
+	public void showOptionsTab() {
+		try {
+			showOptionsTabInternal();
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private void showOptionsTabInternal() throws Exception {
+		var main = GUIMain.getInstance();
+		main.setAlwaysOnTop(true);
+		main.setVisible(true);
+		main.getTabbedPane().setSelectedIndex(GUIMain.Panes.OPTIONS.ordinal());
+		main.setAlwaysOnTop(false);
+	}
+
+	@Override
+	public boolean confirmOverwriteConfig() {
+		try {
+			return confirmOverwriteConfigInternal();
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+	private boolean confirmOverwriteConfigInternal() throws Exception {
+		var main = GUIMain.getInstance();
+		main.setAlwaysOnTop(true);
+		main.setVisible(true);
+		int option = JOptionPane.showConfirmDialog(main, I18nString.get("Do you want to overwrite config?"),
+				I18nString.get("Loading config"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+		main.setAlwaysOnTop(false);
+		return option == JOptionPane.YES_OPTION;
+	}
+}


### PR DESCRIPTION
UIとロジックコードの分離の第一歩として、PacketProxyHubから設定をダウンロードする際に使用する `ConfigHttpServer` のロジック部分とUI部分を分離しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

