### PR TITLE
refactor: remove GUILog singleton and own instance in Logging

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUILog.java
+++ b/src/main/java/core/packetproxy/gui/GUILog.java
@@ -31,16 +31,7 @@ public class GUILog {
 	private JTextPane text;
 	private JScrollPane scrollPane;
 	private JPanel mainPanel;
-	private static GUILog instance;
 	private Object thread_lock;
-
-	public static GUILog getInstance() {
-		if (instance == null) {
-
-			instance = new GUILog();
-		}
-		return instance;
-	}
 
 	public GUILog() {
 		text = new JTextPane();

--- a/src/main/java/core/packetproxy/gui/GUIMain.java
+++ b/src/main/java/core/packetproxy/gui/GUIMain.java
@@ -38,6 +38,7 @@ import packetproxy.model.Database;
 import packetproxy.model.Database.DatabaseMessage;
 import packetproxy.model.InterceptModel;
 import packetproxy.model.PropertyChangeEventType;
+import packetproxy.util.Logging;
 import packetproxy.util.PacketProxyUtility;
 
 public class GUIMain extends JFrame implements PropertyChangeListener {
@@ -53,7 +54,6 @@ public class GUIMain extends JFrame implements PropertyChangeListener {
 	private GUIBulkSender gui_bulksender;
 	private GUIExtensions gui_extensions;
 	private GUIVulCheckHelper gui_vulcheckhelper;
-	private GUILog gui_log;
 	private InterceptModel interceptModel;
 
 	public enum Panes {
@@ -118,7 +118,6 @@ public class GUIMain extends JFrame implements PropertyChangeListener {
 			gui_bulksender = GUIBulkSender.getInstance();
 			gui_extensions = GUIExtensions.getInstance();
 			gui_vulcheckhelper = GUIVulCheckHelper.getInstance();
-			gui_log = GUILog.getInstance();
 
 			tabbedpane = new JTabbedPane();
 
@@ -137,7 +136,7 @@ public class GUIMain extends JFrame implements PropertyChangeListener {
 			tabbedpane.addTab(getPaneString(Panes.BULKSENDER), gui_bulksender.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.EXTENSIONS), gui_extensions.createPanel());
 			tabbedpane.addTab(getPaneString(Panes.OPTIONS), gui_option.createPanel());
-			tabbedpane.addTab(getPaneString(Panes.LOG), gui_log.createPanel());
+			tabbedpane.addTab(getPaneString(Panes.LOG), Logging.createLogPanel());
 
 			getContentPane().add(tabbedpane, BorderLayout.CENTER);
 

--- a/src/main/kotlin/core/packetproxy/util/Logging.kt
+++ b/src/main/kotlin/core/packetproxy/util/Logging.kt
@@ -28,6 +28,7 @@ import java.io.RandomAccessFile
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.*
+import javax.swing.JComponent
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.yield
 import org.jline.jansi.Ansi
@@ -37,7 +38,7 @@ import packetproxy.gui.GUILog
 
 object Logging {
   private val dtf: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")
-  private val guiLog: GUILog = GUILog.getInstance()
+  private val guiLog = GUILog()
   private val logger = LoggerFactory.getLogger("")
   private var isGulp: Boolean = false
 
@@ -54,6 +55,8 @@ object Logging {
     if (!logFile.exists()) throw IOException("not found: ${logFile.absolutePath}")
     logFile
   }
+
+  @JvmStatic fun createLogPanel(): JComponent = guiLog.createPanel()
 
   @JvmStatic
   fun init(isGulp: Boolean) {


### PR DESCRIPTION
シングルトンをなくす取り組みです。`GUILog`が一箇所でしか使用されていないため、このシングルトンを削除しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

