### PR TITLE
fix(gui): preserve Raw tab bytes after full copy-paste in Resender

### DIFF
--- a/src/main/java/core/packetproxy/gui/ExtendedTextPane.java
+++ b/src/main/java/core/packetproxy/gui/ExtendedTextPane.java
@@ -28,6 +28,7 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.EventListenerList;
 import javax.swing.event.UndoableEditEvent;
 import javax.swing.event.UndoableEditListener;
+import javax.swing.text.BadLocationException;
 import javax.swing.undo.UndoManager;
 import org.apache.commons.lang3.ArrayUtils;
 import packetproxy.common.BinaryBuffer;
@@ -89,6 +90,10 @@ abstract class ExtendedTextPane extends PlainTextCopyTextPane {
 			public void removeUpdate(DocumentEvent e) {
 				try {
 
+					if (init_flg == true) {
+
+						return;
+					}
 					if (fin_flg == true) {
 
 						fin_flg = false;
@@ -233,6 +238,23 @@ abstract class ExtendedTextPane extends PlainTextCopyTextPane {
 		for (DataChangedListener listener : listenerList.getListeners(DataChangedListener.class)) {
 
 			listener.dataChanged(data);
+		}
+	}
+
+	protected byte[] getLoadedData() {
+		return data;
+	}
+
+	protected void finishDocumentInitialization() {
+		init_flg = false;
+		fin_flg = false;
+		init_count = 0;
+		try {
+
+			prev_text_panel = getDocument().getText(0, getDocument().getLength());
+		} catch (BadLocationException e) {
+
+			errWithStackTrace(e);
 		}
 	}
 

--- a/src/main/java/core/packetproxy/gui/RawTextPane.java
+++ b/src/main/java/core/packetproxy/gui/RawTextPane.java
@@ -402,6 +402,13 @@ public class RawTextPane extends ExtendedTextPane {
 
 	@Override
 	protected String prepareTextForCopy(String selected) {
+		try {
+			if (selected.length() == getDocument().getLength()) {
+				return selected;
+			}
+		} catch (Exception e) {
+			errWithStackTrace(e);
+		}
 		return stripTrailingNewlines(selected);
 	}
 
@@ -425,10 +432,27 @@ public class RawTextPane extends ExtendedTextPane {
 		}
 		String charSetName = charSetUtility.getCharSet();
 		setText(new String(data, charSetName));
+		finishDocumentInitialization();
 		undo_manager.discardAllEdits();
 	}
 
 	public byte[] getData() {
+		var loadedData = getLoadedData();
+		if (loadedData != null) {
+			try {
+
+				var documentText = getDocument().getText(0, getDocument().getLength());
+				var charSetName = charSetUtility.getCharSet();
+				var loadedText = new String(loadedData, charSetName);
+				if (normalizeForComparison(documentText).equals(normalizeForComparison(loadedText))) {
+
+					return Arrays.copyOf(loadedData, loadedData.length);
+				}
+			} catch (Exception e) {
+
+				errWithStackTrace(e);
+			}
+		}
 		return raw_data.toByteArray();
 	}
 
@@ -447,11 +471,16 @@ public class RawTextPane extends ExtendedTextPane {
 			prev_text_panel = "";
 			raw_data.reset(text.getBytes());
 			super.setText(text);
+			finishDocumentInitialization();
 			undo_manager.discardAllEdits();
 		} catch (Exception e) {
 
 			errWithStackTrace(e);
 		}
+	}
+
+	private static String normalizeForComparison(String s) {
+		return stripTrailingNewlines(s.replace("\r\n", "\n").replace("\r", "\n"));
 	}
 
 	private static String stripTrailingNewlines(String s) {

--- a/src/test/java/packetproxy/gui/RawTextPaneTest.java
+++ b/src/test/java/packetproxy/gui/RawTextPaneTest.java
@@ -1,0 +1,88 @@
+package packetproxy.gui;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import javax.swing.SwingUtilities;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import packetproxy.model.Database;
+import packetproxy.util.CharSetUtility;
+
+class RawTextPaneTest {
+
+	private static final byte[] HTTP_REQUEST = "GET / HTTP/1.1\r\nHost: example\r\n\r\n"
+			.getBytes(StandardCharsets.UTF_8);
+
+	@BeforeAll
+	static void setUpHeadless() throws Exception {
+		System.setProperty("java.awt.headless", "true");
+		var tempDb = Files.createTempFile("packetproxy-raw-text-pane-test", ".sqlite3");
+		tempDb.toFile().deleteOnExit();
+		Database.getInstance().openAt(tempDb.toString());
+	}
+
+	@BeforeEach
+	void setUpCharset() {
+		CharSetUtility.getInstance().setCharSet("UTF-8");
+	}
+
+	@Test
+	void setData_clearsInitFlagAndReturnsOriginalBytes() throws Exception {
+		var pane = new RawTextPane();
+		SwingUtilities.invokeAndWait(() -> {
+			try {
+
+				pane.setData(HTTP_REQUEST, false);
+			} catch (Exception e) {
+
+				throw new RuntimeException(e);
+			}
+		});
+
+		assertFalse(pane.init_flg);
+		assertThat(pane.getData()).isEqualTo(HTTP_REQUEST);
+	}
+
+	@Test
+	void fullDocumentReplace_returnsOriginalBytes() throws Exception {
+		var pane = new RawTextPane();
+		SwingUtilities.invokeAndWait(() -> {
+			try {
+
+				pane.setData(HTTP_REQUEST, false);
+				var doc = pane.getDocument();
+				var text = doc.getText(0, doc.getLength());
+				doc.remove(0, doc.getLength());
+				doc.insertString(0, text, null);
+			} catch (Exception e) {
+
+				throw new RuntimeException(e);
+			}
+		});
+
+		assertThat(pane.getData()).isEqualTo(HTTP_REQUEST);
+	}
+
+	@Test
+	void partialEdit_returnsModifiedBytes() throws Exception {
+		var pane = new RawTextPane();
+		SwingUtilities.invokeAndWait(() -> {
+			try {
+
+				pane.setData(HTTP_REQUEST, false);
+				var doc = pane.getDocument();
+				doc.remove(4, 1);
+				doc.insertString(4, "X", null);
+			} catch (Exception e) {
+
+				throw new RuntimeException(e);
+			}
+		});
+
+		assertThat(pane.getData()).isNotEqualTo(HTTP_REQUEST);
+	}
+}


### PR DESCRIPTION
Resenderのリクエストを全部削除して書き換えたあとに、正しくないリクエストが送信されるバグを修正します。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

