### PR TITLE
GitHub Actions ランナーのNode.js 24対応

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
             - name: Set up JDK 17
-              uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+              uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
               with:
                   java-version: "17"
                   distribution: "temurin"
@@ -23,7 +23,7 @@ jobs:
               run: chmod +x gradlew
 
             - name: Set up Gradle
-              uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+              uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
             - name: Check format with Spotless
               run: ./gradlew spotlessCheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Java CI with Gradle
 
 on:
     push:
-        branches: [master, chore/upgrade-github-actions-node24]
+        branches: [master]
     pull_request:
         branches: [master]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Java CI with Gradle
 
 on:
     push:
-        branches: [master]
+        branches: [master, chore/upgrade-github-actions-node24]
     pull_request:
         branches: [master]
 


### PR DESCRIPTION
GitHub Actions ランナー上でのNode.js 20の非推奨化に伴い、Actionsで使用しているランナーをNode.js 24対応のものに更新しました。
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

