### PR TITLE
fix(gui): correct log tab text selection offset

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUILog.java
+++ b/src/main/java/core/packetproxy/gui/GUILog.java
@@ -52,7 +52,7 @@ public class GUILog {
 
 			synchronized (thread_lock) {
 				StyledDocument doc = text.getStyledDocument();
-				doc.insertString(doc.getLength(), s + "\n\r", null);
+				doc.insertString(doc.getLength(), s + "\n", null);
 			}
 		} catch (BadLocationException ex) {
 
@@ -67,7 +67,7 @@ public class GUILog {
 				StyleConstants.setBackground(keyWord, new Color(240, 150, 150));
 				StyleConstants.setBold(keyWord, true);
 				StyledDocument doc = text.getStyledDocument();
-				doc.insertString(doc.getLength() - 1, s + "\n", keyWord);
+				doc.insertString(doc.getLength(), s + "\n", keyWord);
 			}
 		} catch (BadLocationException ex) {
 


### PR DESCRIPTION
Logタブで文字列を選択すると、選択範囲が半文字分くらいずれる問題を解決しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

