### PR TITLE
fix(gui): unify HTTP copy charset handling via CharSetUtility

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIHistoryContextMenuFactory.java
+++ b/src/main/java/core/packetproxy/gui/GUIHistoryContextMenuFactory.java
@@ -15,6 +15,8 @@
  */
 package packetproxy.gui;
 
+import static packetproxy.gui.HttpPacketClipboardKt.copyMethodUrlBody;
+import static packetproxy.gui.HttpPacketClipboardKt.copyUrl;
 import static packetproxy.util.Logging.errWithStackTrace;
 
 import java.awt.Color;
@@ -39,7 +41,6 @@ import packetproxy.http.HeaderField;
 import packetproxy.http.Http;
 import packetproxy.model.Packet;
 import packetproxy.model.Packets;
-import packetproxy.util.CharSetUtility;
 
 /**
  * Extracted popup menu builder and action wiring for GUIHistory. Reduces the
@@ -130,17 +131,7 @@ public class GUIHistoryContextMenuFactory {
 				KeyStroke.getKeyStroke(KeyEvent.VK_M, mask_key), e -> {
 					try {
 						Packet packet = gui_packet.getPacket();
-						Http http = Http.create(packet.getDecodedData());
-						CharSetUtility charsetutil = CharSetUtility.getInstance();
-						if (charsetutil.isAuto()) {
-							charsetutil.setGuessedCharSet(http.getBody());
-						}
-						String copyData = http.getMethod() + "\t"
-								+ http.getURL(packet.getServerPort(), packet.getUseSSL()) + "\t"
-								+ new String(http.getBody(), charsetutil.getCharSet());
-						Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-						StringSelection selection = new StringSelection(copyData);
-						clipboard.setContents(selection, selection);
+						copyMethodUrlBody(packet.getDecodedData(), packet);
 					} catch (Exception ex) {
 						errWithStackTrace(ex);
 					}
@@ -151,11 +142,7 @@ public class GUIHistoryContextMenuFactory {
 					try {
 						int id = context.getSelectedPacketId();
 						Packet packet = packets.query(id);
-						Http http = Http.create(packet.getDecodedData());
-						String url = http.getURL(packet.getServerPort(), packet.getUseSSL());
-						Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-						StringSelection selection = new StringSelection(url);
-						clipboard.setContents(selection, selection);
+						copyUrl(packet.getDecodedData(), packet);
 					} catch (Exception ex) {
 						errWithStackTrace(ex);
 					}

--- a/src/main/kotlin/core/packetproxy/gui/HttpPacketClipboard.kt
+++ b/src/main/kotlin/core/packetproxy/gui/HttpPacketClipboard.kt
@@ -17,8 +17,10 @@ package packetproxy.gui
 
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
+import java.nio.charset.Charset
 import packetproxy.http.Http
 import packetproxy.model.Packet
+import packetproxy.util.CharSetUtility
 
 fun copyMethodUrlBody(data: ByteArray, packet: Packet) {
   copyToClipboard(formatMethodUrlBody(data, packet))
@@ -26,7 +28,7 @@ fun copyMethodUrlBody(data: ByteArray, packet: Packet) {
 
 fun copyBody(data: ByteArray) {
   val http = Http.create(data)
-  copyToClipboard(String(http.body, Charsets.UTF_8))
+  copyToClipboard(decodeHttpBody(http.body))
 }
 
 fun copyUrl(data: ByteArray, packet: Packet) {
@@ -40,7 +42,15 @@ internal fun formatMethodUrlBody(data: ByteArray, packet: Packet): String {
     "\t" +
     http.getURL(packet.serverPort, packet.useSSL) +
     "\t" +
-    String(http.body, Charsets.UTF_8)
+    decodeHttpBody(http.body)
+}
+
+private fun decodeHttpBody(body: ByteArray): String {
+  val charsetUtility = CharSetUtility.getInstance()
+  if (charsetUtility.isAuto) {
+    charsetUtility.setGuessedCharSet(body)
+  }
+  return String(body, Charset.forName(charsetUtility.charSet))
 }
 
 private fun copyToClipboard(text: String) {

--- a/src/test/kotlin/packetproxy/gui/HttpPacketClipboardTest.kt
+++ b/src/test/kotlin/packetproxy/gui/HttpPacketClipboardTest.kt
@@ -1,12 +1,25 @@
 package packetproxy.gui
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import packetproxy.model.Packet
+import packetproxy.util.CharSetUtility
 
 class HttpPacketClipboardTest {
+  @BeforeEach
+  fun setUp() {
+    val utility = CharSetUtility.getInstance()
+    val charSetField = CharSetUtility::class.java.getDeclaredField("charSet")
+    charSetField.isAccessible = true
+    charSetField.set(utility, "UTF-8")
+    val isAutoField = CharSetUtility::class.java.getDeclaredField("isAuto")
+    isAutoField.isAccessible = true
+    isAutoField.setBoolean(utility, false)
+  }
+
   @Test
   fun formatMethodUrlBody_returnsTabSeparatedMethodUrlAndBody() {
     val data =


### PR DESCRIPTION
URLやリクエストボディ、レスポンスボディのコピー時の処理が、コンテキストメニューから行う場合とHistoryタブ下部のボタンから行う場合とで異なっていましたので、統合しました。

- 従来：コンテキストメニューから行うとUTF-8固定、Historyタブ下部のボタンから行うと文字コードのトグルボックスに従う
- 修正後：いずれの場合も文字コードのトグルボックスに従う

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

