### PR TITLE
refactor(gui): replace title color magic number with named constant

### DIFF
--- a/src/main/java/core/packetproxy/gui/GUIOption.java
+++ b/src/main/java/core/packetproxy/gui/GUIOption.java
@@ -42,6 +42,8 @@ import packetproxy.model.InterceptOptions;
 
 public class GUIOption {
 
+	private static final Color TITLE_FOREGROUND_COLOR = new Color(0, 238, 208);
+
 	private JFrame owner;
 
 	public GUIOption(JFrame owner) {
@@ -50,7 +52,7 @@ public class GUIOption {
 
 	private JComponent createTitle(String title) throws Exception {
 		JLabel label = new JLabel(title);
-		label.setForeground(Color.decode("61136"));
+		label.setForeground(TITLE_FOREGROUND_COLOR);
 		label.setBackground(Color.WHITE);
 		label.setFont(FontManager.getInstance().getUICaptionFont());
 		label.setMaximumSize(new Dimension(Short.MAX_VALUE, label.getMinimumSize().height));


### PR DESCRIPTION
`GUIOption.java`内において、Optionタブの見出しの色が10進数で記載されていましたが、分かりにくいので`new Color`を用いて書き直しました。またそのついでに、定数を導入しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

