### PR TITLE
fix(model): close jar and classloader via try-with-resources in Exten…

### DIFF
--- a/src/main/java/core/packetproxy/model/Extensions.java
+++ b/src/main/java/core/packetproxy/model/Extensions.java
@@ -115,31 +115,29 @@ public class Extensions implements PropertyChangeListener {
 
 			File file = new File(path);
 			URL[] urls = {file.toURI().toURL()};
-			URLClassLoader urlClassLoader = new URLClassLoader(urls);
-			JarFile jar = new JarFile(file);
-			Extension extension = null;
-			for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements();) {
+			try (URLClassLoader urlClassLoader = new URLClassLoader(urls); JarFile jar = new JarFile(file)) {
+				Extension extension = null;
+				for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements();) {
 
-				JarEntry entry = entries.nextElement();
-				String entryName = entry.getName();
-				if (!entryName.endsWith(".class"))
-					continue;
-				String className = entryName.replace("/", ".").substring(0, entryName.length() - 6);
-				try {
-
-					Class clazz = urlClassLoader.loadClass(className);
-					if (!Extension.class.isAssignableFrom(clazz))
+					JarEntry entry = entries.nextElement();
+					String entryName = entry.getName();
+					if (!entryName.endsWith(".class"))
 						continue;
-					Constructor<Extension> constructor = clazz.getConstructor(String.class, String.class);
-					extension = (Extension) constructor.newInstance(name, path);
-				} catch (ClassNotFoundException e1) {
+					String className = entryName.replace("/", ".").substring(0, entryName.length() - 6);
+					try {
 
-					// errWithStackTrace(e1);
+						Class clazz = urlClassLoader.loadClass(className);
+						if (!Extension.class.isAssignableFrom(clazz))
+							continue;
+						Constructor<Extension> constructor = clazz.getConstructor(String.class, String.class);
+						extension = (Extension) constructor.newInstance(name, path);
+					} catch (ClassNotFoundException e1) {
+
+						// errWithStackTrace(e1);
+					}
 				}
+				return extension;
 			}
-			jar.close();
-			urlClassLoader.close();
-			return extension;
 		} catch (Exception e) {
 
 			errWithStackTrace(e);


### PR DESCRIPTION
拡張機能を読み込む際に例外が発生すると、`urlClassLoader`や`jar`が閉じられず、リソースリークが発生するため、これを修正しました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

