### PR TITLE
refactor(model): unify PropertyChangeEvent check via matches()

### DIFF
--- a/src/main/java/core/packetproxy/model/Packets.java
+++ b/src/main/java/core/packetproxy/model/Packets.java
@@ -262,7 +262,7 @@ public class Packets implements PropertyChangeListener {
 
 	@Override
 	public void propertyChange(PropertyChangeEvent evt) {
-		if (DATABASE_MESSAGE.toString().equals(evt.getPropertyName())) {
+		if (DATABASE_MESSAGE.matches(evt)) {
 
 			DatabaseMessage message = (DatabaseMessage) evt.getNewValue();
 			handleDatabaseMessage(message);


### PR DESCRIPTION
`.toString()`による比較ではなく、`.matches()`を使用して簡略にしました。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

