### PR TITLE
fix: restart all listens on server change

### DIFF
--- a/src/main/java/core/packetproxy/ListenPortManager.java
+++ b/src/main/java/core/packetproxy/ListenPortManager.java
@@ -137,7 +137,7 @@ public class ListenPortManager implements PropertyChangeListener {
 			try {
 
 				synchronized (listen_map) {
-					restartAffectedForwarders();
+					restartAffectedListens();
 				}
 			} catch (Exception e) {
 
@@ -154,20 +154,17 @@ public class ListenPortManager implements PropertyChangeListener {
 		}
 	}
 
-	private void restartAffectedForwarders() throws Exception {
+	private void restartAffectedListens() throws Exception {
 		List<ListenPort> list = listenPorts.queryEnabled();
 		for (ListenPort listen_port : list) {
 
-			if (listen_port.getType().isForwarder()) {
+			Listen listen = listen_map.get(listen_port.getProtoPort());
+			if (listen != null) {
 
-				Listen listen = listen_map.get(listen_port.getProtoPort());
-				if (listen != null) {
-
-					log("## restarting forwarder due to server change: %s", listen_port.getProtoPort());
-					listen.close();
-					Listen new_listen = new Listen(listen_port);
-					listen_map.put(listen_port.getProtoPort(), new_listen);
-				}
+				log("## restarting listen due to server change: %s", listen_port.getProtoPort());
+				listen.close();
+				Listen new_listen = new Listen(listen_port);
+				listen_map.put(listen_port.getProtoPort(), new_listen);
 			}
 		}
 	}


### PR DESCRIPTION
サーバのエンコード方式が変更された際、従来は `FORWARDER` のみがリセットされていました。今回の変更により、Listen Portの種類に関わらずリセットが実行されるようになります。 これによって、新しいエンコード方式が即座に適用されます。

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).

